### PR TITLE
Move app-specific configuration from the engine to the app

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/EnvironmentAgency/flood-risk-engine
-  revision: 9f6c8e4432d4da58d4af84cd5b8b5ab9ca7d53da
+  revision: dca074af2ab68522030ef71929fe61584cb2d454
   branch: develop
   specs:
     flood_risk_engine (0.0.1)
@@ -87,7 +87,7 @@ GEM
       ice_nine (~> 0.11.0)
       thread_safe (~> 0.3, >= 0.3.1)
     bcrypt (3.1.11)
-    before_commit (0.8.1)
+    before_commit (0.8.2)
     bootstrap-sass (3.3.5.1)
       autoprefixer-rails (>= 5.0.0.1)
       sass (>= 3.3.0)

--- a/config/initializers/01_airbrake.rb
+++ b/config/initializers/01_airbrake.rb
@@ -1,0 +1,63 @@
+# Airbrake is an online tool that provides robust exception tracking in your Rails
+# applications. In doing so, it allows you to easily review errors, tie an error
+# to an individual piece of code, and trace the cause back to recent
+# changes. Airbrake enables for easy categorization, searching, and prioritization
+# of exceptions so that when errors occur, your team can quickly determine the
+# root cause.
+#
+# Configuration details:
+# https://github.com/airbrake/airbrake-ruby#configuration
+require_dependency "airbrake"
+
+if Rails.env.production?
+
+  Airbrake.configure do |c|
+
+    # You must set both project_id & project_key. To find your project_id and
+    # project_key navigate to your project's General Settings and copy the values
+    # from the right sidebar.
+    # https://github.com/airbrake/airbrake-ruby#project_id--project_key
+    c.host = Rails.application.secrets.airbrake_host
+    c.project_key = Rails.application.secrets.airbrake_project_key
+    c.project_id = true # Errbit doesn't require a specific project_id, so setting to true
+
+    # Configures the root directory of your project. Expects a String or a
+    # Pathname, which represents the path to your project. Providing this option
+    # helps us to filter out repetitive data from backtrace frames and link to
+    # GitHub files from our dashboard.
+    # https://github.com/airbrake/airbrake-ruby#root_directory
+    c.root_directory = Rails.root
+
+    # By default, Airbrake Ruby outputs to STDOUT. In Rails apps it makes sense to
+    # use the Rails' logger.
+    # https://github.com/airbrake/airbrake-ruby#logger
+    c.logger = Rails.logger
+
+    # Configures the environment the application is running in. Helps the Airbrake
+    # dashboard to distinguish between exceptions occurring in different
+    # environments. By default, it's not set.
+    # NOTE: This option must be set in order to make the 'ignore_environments'
+    # option work.
+    # https://github.com/airbrake/airbrake-ruby#environment
+    c.environment = Rails.env
+
+    # Setting this option allows Airbrake to filter exceptions occurring in
+    # unwanted environments such as :test. By default, it is equal to an empty
+    # Array, which means Airbrake Ruby sends exceptions occurring in all
+    # environments.
+    # NOTE: This option *does not* work if you don't set the 'environment' option.
+    # https://github.com/airbrake/airbrake-ruby#ignore_environments
+    c.ignore_environments = %w[development test]
+
+    # A list of parameters that should be filtered out of what is sent to
+    # Airbrake. By default, all "password" attributes will have their contents
+    # replaced.
+    # https://github.com/airbrake/airbrake-ruby#blacklist_keys
+    c.blacklist_keys = [/password/i]
+  end
+
+  # If Airbrake doesn't send any expected exceptions, we suggest to uncomment the
+  # line below. It might simplify debugging of background Airbrake workers, which
+  # can silently die.
+  # Thread.abort_on_exception = ['test', 'development'].include?(Rails.env)
+end

--- a/config/initializers/address_lookup.rb
+++ b/config/initializers/address_lookup.rb
@@ -1,0 +1,8 @@
+EA::AddressLookup.configure do |config|
+  config.address_facade_server    = Rails.application.secrets.address_facade_server
+  config.address_facade_port      = Rails.application.secrets.address_facade_port
+  config.address_facade_url       = "/address-service/v1/addresses/postcode"
+  config.timeout_in_seconds       = Rails.application.secrets.address_facade_timeout
+  config.address_facade_client_id = Rails.application.secrets.address_facade_client_id
+  config.address_facade_key       = Rails.application.secrets.address_facade_key
+end

--- a/config/initializers/area_lookup.rb
+++ b/config/initializers/area_lookup.rb
@@ -1,0 +1,3 @@
+EA::AreaLookup.configure do |config|
+  # config.administrative_area_api_url = ?
+end

--- a/config/initializers/exports.rb
+++ b/config/initializers/exports.rb
@@ -1,0 +1,4 @@
+
+export_directory = Rails.root.join("private", "exports")
+
+FileUtils.mkdir_p(export_directory) unless File.directory?(export_directory)

--- a/config/initializers/flood_risk_engine.rb
+++ b/config/initializers/flood_risk_engine.rb
@@ -1,11 +1,7 @@
 FloodRiskEngine.configure do |config|
-  # By de3fault we use a different layout to the host app (ie we don't use application by default)
+  # By default we use a different layout to the host app (ie we don't use application by default)
   # because that layout may include calls to helper methods that we (as an isolated engine)
-  # don;t have access to.
+  # don't have access to.
   config.layout = "flood_risk_engine"
   config.require_journey_completed_in_same_browser = false
 end
-
-export_directory = Rails.root.join("private", "exports")
-
-FileUtils.mkdir_p(export_directory) unless File.directory?(export_directory)

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -16,21 +16,14 @@ defaults: &defaults
   aws_access_key_id: <%= ENV['AWS_ACCESS_KEY_ID'] %>
   aws_secret_access_key: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
   aws_region: <%= ENV['AWS_REGION'] || 'eu-west-1' %>
-  # Please note, this is actually a string which is evaluated when used, and not some
-  # ruby code which has not been properly tagged.
-  exemptions_expire_after: 3.years - 1.day
 
 development:
   <<: *defaults
   secret_key_base: 5b456be22062e002d232c2aed8996d48a47bbd6916c34c62d5eb0584769a2611c1f0dd83a6220f5d4d682b521709b3f944cf112cb5a1a45b1528dbfe361c2f01
-  address_facade_server: <%= ENV['ADDRESS_FACADE_TEST_SERVER'] %>
-  address_facade_port: <%= ENV['ADDRESS_FACADE_TEST_PORT'] %>
 
 test:
   <<: *defaults
   secret_key_base: a7e6e3347850a7301d756bc63d95cc32c6dc1a425d93f04ec2b960b8519c67953919c17fdd904f35792be3ffe88acf87f075f2f78351757abad2b142787ca3409
-  address_facade_server: <%= ENV['ADDRESS_FACADE_TEST_SERVER'] %>
-  address_facade_port: <%= ENV['ADDRESS_FACADE_TEST_PORT'] %>
 
 production: &production
   <<: *defaults

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -107,6 +107,7 @@ ActiveRecord::Schema.define(version: 20160629131906) do
     t.integer  "secondary_contact_id"
     t.string   "reference_number",          limit: 12
     t.integer  "updated_by_user_id"
+    t.integer  "status",                               default: 0, null: false
     t.datetime "submitted_at"
   end
 


### PR DESCRIPTION
Rather than for example having an initialiser in the
engine to setup the address_lookup configuration, let the host
app do this.
