### PR TITLE
Style enrollment steps in the back office

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem "uglifier", "~> 3.0"      # Use Uglifier as compressor for JavaScript assets
 gem "coffee-rails", "~> 4.1"  # Use CoffeeScript for .coffee assets and views
 gem "govuk_admin_template", "~> 4.1"
 gem "govuk_frontend_toolkit", "~> 4.9" # Added this to get Tabs for Choosing Exemption working
+gem "govuk_elements_rails", "~> 1.2.1"
 gem "simple_form", "~> 3.2"
 gem "pundit", "~> 1.1"
 gem "devise", "~> 3.5"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/EnvironmentAgency/flood-risk-engine
-  revision: 0b7b7f0f993510272468d7fc311da8f990ac0c50
+  revision: cc3e03f166afd8f15f5e49e31570d91338287cf9
   branch: develop
   specs:
     flood_risk_engine (0.0.1)
@@ -183,6 +183,10 @@ GEM
       bootstrap-sass (= 3.3.5.1)
       jquery-rails (~> 3.1.3)
       rails (>= 3.2.0)
+    govuk_elements_rails (1.2.1)
+      govuk_frontend_toolkit (>= 4.12.0)
+      rails (>= 4.1.0)
+      sass (>= 3.2.0)
     govuk_frontend_toolkit (4.12.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
@@ -443,6 +447,7 @@ DEPENDENCIES
   foreman
   fuubar
   govuk_admin_template (~> 4.1)
+  govuk_elements_rails (~> 1.2.1)
   govuk_frontend_toolkit (~> 4.9)
   i18n-tasks (~> 0.9.5)
   kaminari (~> 0.16)

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -24,4 +24,3 @@
 .block-label {
   display: block;
 }
-

--- a/app/assets/stylesheets/back_office.css.scss
+++ b/app/assets/stylesheets/back_office.css.scss
@@ -1,0 +1,20 @@
+@import 'govuk-elements';
+
+.form-group {
+  float: none;
+}
+
+.error-summary > h1 {
+  color: inherit;
+  padding: 0;
+  background-color: transparent;
+  border-color: transparent;
+}
+
+.text, .panel {
+  max-width: 30em;
+}
+
+.flood_risk_engine div.form-group.error > label {
+  color: inherit;
+}

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -4,7 +4,7 @@
     <li class="dropdown">
       <a href="#" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"
          role="button"><%= glyphicon_tag :file %>
-        <%= FloodRiskEngine::Enrollment.model_name.human(count: 2) %>
+        <%= t('.enrollments_dropdown') %>
         <span class="caret"></span></a>
 
       <ul class="dropdown-menu">

--- a/app/views/layouts/flood_risk_engine.html.erb
+++ b/app/views/layouts/flood_risk_engine.html.erb
@@ -1,5 +1,6 @@
 <%- content_for :head do -%>
   <%= stylesheet_link_tag "application", media: "all" %>
+  <%= stylesheet_link_tag "back_office", media: "all" %>
   <%= javascript_include_tag "application", media: "all" %>
   <%= csrf_meta_tags %>
 <%- end -%>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -8,4 +8,4 @@ Rails.application.config.assets.version = "1.0"
 
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
-# Rails.application.config.assets.precompile += %w( search.js )
+Rails.application.config.assets.precompile += %w( back_office.css )

--- a/config/locales/views.yml
+++ b/config/locales/views.yml
@@ -1,6 +1,7 @@
 en:
   layouts:
     navbar:
+      enrollments_dropdown: Registrations
       new_enrollment: New
       export_enrollments: Export
       search_enrollments: Search
@@ -96,4 +97,3 @@ en:
   #     new:
   #       subtitle1: For your security this account may be locked if you or someone else repeatedly tries to sign in using incorrect details.
   #       subtitle2: Enter the email address used to register this account. You'll then receive account unlocking guidance by email.
-


### PR DESCRIPTION
Bring in govuk elements to help style the enrollment steps in the back
office. Also rename Enrollments to Registrations in the navbar menu.

No RIP number as I worked with Polly on this.
