### PR TITLE
RIP-166 Use papertrail to track changes to enrollment and enrollment exemptions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/EnvironmentAgency/flood-risk-engine
-  revision: cc3e03f166afd8f15f5e49e31570d91338287cf9
+  revision: 97db77eda3d9f7a886a818d89aa54d69e7d219e0
   branch: develop
   specs:
     flood_risk_engine (0.0.1)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,7 @@ class ApplicationController < ActionController::Base
     {
       ip: request.remote_ip,
       user_agent: request.user_agent,
-      whodunnit_email: current_user.email
+      whodunnit_email: current_user.try(:email)
     }
   end
 

--- a/app/decorators/models/flood_risk_engine/enrollment_decorator.rb
+++ b/app/decorators/models/flood_risk_engine/enrollment_decorator.rb
@@ -1,3 +1,0 @@
-FloodRiskEngine::Enrollment.class_eval do
-  has_paper_trail
-end

--- a/app/decorators/models/flood_risk_engine/enrollment_exemption_decorator.rb
+++ b/app/decorators/models/flood_risk_engine/enrollment_exemption_decorator.rb
@@ -1,6 +1,4 @@
 FloodRiskEngine::EnrollmentExemption.class_eval do
-  has_paper_trail meta: { status: :status }
-
   belongs_to :accept_reject_decision_user, class_name: "User"
 
   # rubocop:disable Style/Lambda

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,6 @@
 
 class User < ActiveRecord::Base
   attr_accessor :assigned_role
-  has_paper_trail
 
   rolify role_cname: "Role",
          role_join_table_name: "users_roles",

--- a/config/initializers/paper_trail.rb
+++ b/config/initializers/paper_trail.rb
@@ -1,3 +1,20 @@
 PaperTrail.configure do |config|
-  config.track_associations = false
+  config.track_associations = true
 end
+
+
+require "paper_trail"
+
+module FloodRiskEngine
+  Enrollment.has_paper_trail          meta: { status: :step }
+  EnrollmentExemption.has_paper_trail meta: { status: :status }
+  Address.has_paper_trail
+  Contact.has_paper_trail
+  Location.has_paper_trail
+  Organisation.has_paper_trail
+  Partner.has_paper_trail
+  ReferenceNumber.has_paper_trail     meta: { status: :number }
+end
+
+User.has_paper_trail
+Role.has_paper_trail

--- a/db/migrate/20160708115202_create_version_associations.rb
+++ b/db/migrate/20160708115202_create_version_associations.rb
@@ -1,0 +1,22 @@
+# This migration and AddTransactionIdColumnToVersions provide the necessary
+# schema for tracking associations.
+class CreateVersionAssociations < ActiveRecord::Migration
+  def self.up
+    create_table :version_associations do |t|
+      t.integer  :version_id
+      t.string   :foreign_key_name, null: false
+      t.integer  :foreign_key_id
+    end
+    add_index :version_associations, [:version_id]
+    add_index :version_associations,
+      [:foreign_key_name, :foreign_key_id],
+      name: "index_version_associations_on_foreign_key"
+  end
+
+  def self.down
+    remove_index :version_associations, [:version_id]
+    remove_index :version_associations,
+      name: "index_version_associations_on_foreign_key"
+    drop_table :version_associations
+  end
+end

--- a/db/migrate/20160708115203_add_transaction_id_column_to_versions.rb
+++ b/db/migrate/20160708115203_add_transaction_id_column_to_versions.rb
@@ -1,0 +1,13 @@
+# This migration and CreateVersionAssociations provide the necessary
+# schema for tracking associations.
+class AddTransactionIdColumnToVersions < ActiveRecord::Migration
+  def self.up
+    add_column :versions, :transaction_id, :integer
+    add_index :versions, [:transaction_id]
+  end
+
+  def self.down
+    remove_index :versions, [:transaction_id]
+    remove_column :versions, :transaction_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160708104607) do
+ActiveRecord::Schema.define(version: 20160708115203) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -106,15 +106,15 @@ ActiveRecord::Schema.define(version: 20160708104607) do
     t.integer  "correspondence_contact_id"
     t.string   "token"
     t.integer  "secondary_contact_id"
-    t.string   "reference_number",          limit: 12
     t.integer  "updated_by_user_id"
     t.datetime "submitted_at"
+    t.integer  "reference_number_id"
   end
 
   add_index "flood_risk_engine_enrollments", ["applicant_contact_id"], name: "index_flood_risk_engine_enrollments_on_applicant_contact_id", using: :btree
   add_index "flood_risk_engine_enrollments", ["correspondence_contact_id"], name: "fre_enrollments_correspondence_contact_id", using: :btree
   add_index "flood_risk_engine_enrollments", ["organisation_id"], name: "index_flood_risk_engine_enrollments_on_organisation_id", using: :btree
-  add_index "flood_risk_engine_enrollments", ["reference_number"], name: "index_flood_risk_engine_enrollments_on_reference_number", unique: true, using: :btree
+  add_index "flood_risk_engine_enrollments", ["reference_number_id"], name: "index_flood_risk_engine_enrollments_on_reference_number_id", unique: true, using: :btree
   add_index "flood_risk_engine_enrollments", ["token"], name: "index_flood_risk_engine_enrollments_on_token", unique: true, using: :btree
   add_index "flood_risk_engine_enrollments", ["updated_by_user_id"], name: "index_flood_risk_engine_enrollments_on_updated_by_user_id", using: :btree
 
@@ -180,6 +180,14 @@ ActiveRecord::Schema.define(version: 20160708104607) do
   add_index "flood_risk_engine_partners", ["contact_id"], name: "index_flood_risk_engine_partners_on_contact_id", using: :btree
   add_index "flood_risk_engine_partners", ["organisation_id"], name: "index_flood_risk_engine_partners_on_organisation_id", using: :btree
 
+  create_table "flood_risk_engine_reference_numbers", force: :cascade do |t|
+    t.string   "number"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_index "flood_risk_engine_reference_numbers", ["number"], name: "index_flood_risk_engine_reference_numbers_on_number", using: :btree
+
   create_table "roles", force: :cascade do |t|
     t.string   "name"
     t.integer  "resource_id"
@@ -242,6 +250,15 @@ ActiveRecord::Schema.define(version: 20160708104607) do
 
   add_index "users_roles", ["user_id", "role_id"], name: "index_users_roles_on_user_id_and_role_id", using: :btree
 
+  create_table "version_associations", force: :cascade do |t|
+    t.integer "version_id"
+    t.string  "foreign_key_name", null: false
+    t.integer "foreign_key_id"
+  end
+
+  add_index "version_associations", ["foreign_key_name", "foreign_key_id"], name: "index_version_associations_on_foreign_key", using: :btree
+  add_index "version_associations", ["version_id"], name: "index_version_associations_on_version_id", using: :btree
+
   create_table "versions", force: :cascade do |t|
     t.string   "item_type",       null: false
     t.integer  "item_id",         null: false
@@ -253,9 +270,11 @@ ActiveRecord::Schema.define(version: 20160708104607) do
     t.string   "whodunnit_email"
     t.string   "ip"
     t.string   "user_agent"
+    t.integer  "transaction_id"
   end
 
   add_index "versions", ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id", using: :btree
+  add_index "versions", ["transaction_id"], name: "index_versions_on_transaction_id", using: :btree
 
   add_foreign_key "flood_risk_engine_address_searches", "flood_risk_engine_enrollments", column: "enrollment_id"
   add_foreign_key "flood_risk_engine_contacts", "flood_risk_engine_organisations", column: "partnership_organisation_id"


### PR DESCRIPTION
[RIP-166](https://eaflood.atlassian.net/browse/RIP-166)

Adds paper trail to most models. It didn't seem to pick up changes to status, so I added status as meta data (note that the preserved status is the one it was changed from - not the status it was changed to).

I've also added some additional data from the controller: the current user's email address, their IP and user agent.
