### PR TITLE
RIP-287 Fix validation error summary

### DIFF
--- a/app/views/shared/_flash_alerts.html.erb
+++ b/app/views/shared/_flash_alerts.html.erb
@@ -1,4 +1,5 @@
-<% flash.each do |type, message| %>
+<% flashes = flash.to_hash.symbolize_keys.slice(:success, :alert, :notice, :info, :warn, :not_authorized) %>
+<% flashes.each do |type, message| %>
   <div class="alert <%= bootstrap_alert_class_for(type) %> fade in" role="alert" alert-dismissible>
     <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
     <%= message %>


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RIP-287

As part of this ticket I decided to simplify some of the logic around
displaying flash messages and error notices.

I moved the Boostrap class selection to a helper based on this:
https://gist.github.com/roberto/3344628
