### PR TITLE
Set Fully Assisted mode on new BO Enrollment  - RIP-218 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/EnvironmentAgency/flood-risk-engine
-  revision: 3fd8e918d8fd35fb22b4e874f5f3816fe79e2dac
+  revision: f2b68768900bcd9253903090081d9dd9e8df1282
   branch: develop
   specs:
     flood_risk_engine (0.0.1)

--- a/app/controllers/admin/enrollment_exemptions/assistance_controller.rb
+++ b/app/controllers/admin/enrollment_exemptions/assistance_controller.rb
@@ -12,7 +12,7 @@ module Admin
         form = form_factory
         if form.validate(params) && form.save
 
-          display_mode = EnrollmentExemptionPresenter.assistance_mode_text(assistance_mode)
+          display_mode = presenter_factory.assistance_mode_text
 
           redirect_to [:admin, enrollment_exemption], notice: t(".notice", mode: display_mode)
         else

--- a/app/controllers/admin/enrollments_controller.rb
+++ b/app/controllers/admin/enrollments_controller.rb
@@ -2,23 +2,11 @@ module Admin
   class EnrollmentsController < ApplicationController
     def new
       authorize FloodRiskEngine::Enrollment
-      redirect_to flood_risk_engine.new_enrollment_path
+
+      enrollment = FloodRiskEngine::Enrollment.create(updated_by_user_id: current_user.id)
+
+      redirect_to flood_risk_engine.enrollment_step_path(enrollment, enrollment.initial_step)
     end
-
-    # def create
-    #   authorize FloodRiskEngine::Enrollment
-
-    #   en = FloodRiskEngine::Enrollment.create #! state_event: "commence",
-    #                                           #   assistance_mode: "full",
-    #                                           #   created_by: current_user.email,
-    #                                           #   updated_by: current_user.email
-
-    #   # msg = I18n.t :admin_enrollment_create_success,
-    #   #              assistance_mode: I18n.t(en.assistance_mode, scope: :assistance_modes),
-    #   #              ref: en.reference_number
-
-    #   redirect_to flood_risk_engine.step_enrollment_path(en)#.state, en)#, notice: msg
-    # end
 
     def index
       authorize FloodRiskEngine::Enrollment
@@ -44,11 +32,12 @@ module Admin
       redirect_to flood_risk_engine.enrollment_step_path(@enrollment, @enrollment.initial_step)
     end
 
-    def resume
-      load_and_authorise_enrollment
-      @enrollment.update! updated_by: current_user.email
-      redirect_to digital_services_core.enrollment_state_path(@enrollment.state, @enrollment)
-    end
+    #  digital_services_core redundant so commenting out for now - not sure why this method here
+    #     def resume
+    #       load_and_authorise_enrollment
+    #       @enrollment.update! updated_by: current_user.email
+    #       redirect_to digital_services_core.enrollment_state_path(@enrollment.state, @enrollment)
+    #     end
 
     def load_and_authorise_enrollment
       @enrollment = FloodRiskEngine::Enrollment.find_by_token! params[:id]

--- a/app/decorators/models/flood_risk_engine/enrollment_exemption_decorator.rb
+++ b/app/decorators/models/flood_risk_engine/enrollment_exemption_decorator.rb
@@ -1,13 +1,6 @@
 FloodRiskEngine::EnrollmentExemption.class_eval do
   belongs_to :accept_reject_decision_user, class_name: "User"
 
-  enum assistance_mode: {
-    unassisted: 0,
-    full: 1,
-    partial: 2,
-    admin_intervention: 3
-  }
-
   # rubocop:disable Style/Lambda
 
   scope :by_submitted_at, ->(start_date, end_date) {

--- a/app/forms/admin/enrollment_exemptions/assistance_form.rb
+++ b/app/forms/admin/enrollment_exemptions/assistance_form.rb
@@ -18,6 +18,7 @@ module Admin
       include Admin::EnrollmentExemptions::Concerns::CommentableForm
 
       alias enrollment_exemption model
+      delegate :enrollment, to: :enrollment_exemption
 
       property :assistance_mode
 
@@ -30,6 +31,9 @@ module Admin
 
       def save
         super
+
+        enrollment.update(updated_by_user_id: user.id) unless assistance_mode == "unassisted"
+
         mode = self.class.t("modes.#{assistance_mode}")
         create_comment("Updated Assistance Mode to #{mode}", user)
       end

--- a/app/models/enrollment_export.rb
+++ b/app/models/enrollment_export.rb
@@ -32,11 +32,11 @@ class EnrollmentExport < ActiveRecord::Base
   end
 
   def writer
-    @writer ||= WriteEnrollmentExportReport.new(self, csv_data)
+    @writer ||= WriteEnrollmentExportReport.new(self)
   end
 
   def run
-    writer.call
+    writer.run(csv_data)
 
     WriteToAwsS3.run(self) unless ENV["EXPORT_USE_FILESYSTEM_NOT_AWS_S3"]
 

--- a/app/presenters/concerns/partnership_presenter.rb
+++ b/app/presenters/concerns/partnership_presenter.rb
@@ -37,7 +37,7 @@ module PartnershipPresenter
     values += [
       reference_number,
       submitted_at,
-      "" # TODO:  Assisted digital
+      assistance_mode_text
     ]
 
     values

--- a/app/services/prepare_enrollment_export_report.rb
+++ b/app/services/prepare_enrollment_export_report.rb
@@ -32,25 +32,31 @@ class PrepareEnrollmentExportReport
   def generate_row(enrollment_exemption)
     @current_enrollment_exemption = enrollment_exemption
 
-    enrollment = enrollment_exemption.enrollment
+    enrollment          = enrollment_exemption.enrollment
+    exemption_location  = enrollment.exemption_location
+
+    presenter = EnrollmentExemptionPresenter.new(enrollment_exemption, nil)
 
     [
       enrollment_exemption.status,
-      ldate(enrollment.submitted_at, format: :long),
+      presenter.submitted_at,
       ldate(enrollment_exemption.accept_reject_decision_at, format: :long),
       enrollment_exemption.accept_reject_decision_user.try(:email),
       enrollment_export.created_by,
-      enrollment.reference_number,
-      enrollment.exemption_location.grid_reference,
-      enrollment.exemption_location.description,
-      "#{enrollment.exemption_location.easting},#{enrollment.exemption_location.northing}",
-      "", # TODO: EA Area
-      enrollment.exemptions.first.code,
-      enrollment.organisation.org_type,
+      presenter.deregister_reason_text,
+      presenter.assistance_mode_text,
+      presenter.assistance_user,
+      presenter.reference_number,
+      presenter.grid_reference,
+      presenter.description,
+      "#{exemption_location.easting},#{exemption_location.northing}",
+      presenter.water_boundary_area_long_name,
+      presenter.code,
+      presenter.org_type,
       enrollment.correspondence_contact.full_name,
       enrollment.correspondence_contact.email_address,
       enrollment.correspondence_contact.telephone_number,
-      enrollment.organisation.name,
+      presenter.organisation_name,
       comments(enrollment_exemption),
       linkage_url
     ]
@@ -63,17 +69,20 @@ class PrepareEnrollmentExportReport
 
   def self.column_names
     [
-      "Registration status",              # 1.
+      "Registration status",
       "Submitted date",
       "Decision date",
       "Decision maker",
       "Created by",
+      "Deregister reason",
+      "Assistance mode",
+      "Assistance user",
       "Exemption reference number",
       "NGR",
-      "Site description",
+      "Site description", # 10
       "Easting and Northing",
       "EA area",
-      "Exemption code and description",   # 10.
+      "Exemption code and description",
       "Business type",
       "Contact name",
       "Contact email",

--- a/app/services/write_enrollment_export_report.rb
+++ b/app/services/write_enrollment_export_report.rb
@@ -1,9 +1,8 @@
 
 class WriteEnrollmentExportReport
 
-  def initialize(enrollment_export, csv_data)
+  def initialize(enrollment_export)
     @enrollment_export = enrollment_export
-    @csv_data = csv_data
   end
 
   def column_names
@@ -22,8 +21,10 @@ class WriteEnrollmentExportReport
     enrollment_export.update!(state: :failed, failure_text: message)
   end
 
-  def call
+  def run(csv_data)
     started
+
+    @csv_data = csv_data
 
     CSV.open(enrollment_export.full_path, "wb", force_quotes: true) do |csv|
       csv << column_names

--- a/config/locales/admin/enrollment_exemptions/assistance.yml
+++ b/config/locales/admin/enrollment_exemptions/assistance.yml
@@ -12,7 +12,7 @@ en:
             blank: Enter a comment
         modes:
           unassisted: Unassisted
-          full: Fully assisted
+          fully_assisted: Fully assisted
           partial: Partially assisted
           admin_intervention: Admin Intervention
         update:

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -109,6 +109,7 @@ ActiveRecord::Schema.define(version: 20160712104613) do
     t.datetime "submitted_at"
     t.integer  "updated_by_user_id"
     t.integer  "reference_number_id"
+    t.integer  "updated_by_user_id"
   end
 
   add_index "flood_risk_engine_enrollments", ["applicant_contact_id"], name: "index_flood_risk_engine_enrollments_on_applicant_contact_id", using: :btree
@@ -299,7 +300,6 @@ ActiveRecord::Schema.define(version: 20160712104613) do
   add_foreign_key "flood_risk_engine_enrollments", "flood_risk_engine_contacts", column: "applicant_contact_id"
   add_foreign_key "flood_risk_engine_enrollments", "flood_risk_engine_contacts", column: "secondary_contact_id"
   add_foreign_key "flood_risk_engine_enrollments", "flood_risk_engine_organisations", column: "organisation_id"
-  add_foreign_key "flood_risk_engine_enrollments", "users", column: "updated_by_user_id"
   add_foreign_key "flood_risk_engine_enrollments_exemptions", "flood_risk_engine_enrollments", column: "enrollment_id"
   add_foreign_key "flood_risk_engine_enrollments_exemptions", "flood_risk_engine_exemptions", column: "exemption_id"
   add_foreign_key "flood_risk_engine_organisations", "flood_risk_engine_contacts", column: "contact_id"

--- a/spec/factories/enrollments_factory.rb
+++ b/spec/factories/enrollments_factory.rb
@@ -19,7 +19,9 @@ FactoryGirl.define do
 
   factory :confirmed_random_pending, parent: :base_back_office_enrollment do
     after(:create) do |object|
-      exemption = FloodRiskEngine::Exemption.offset(rand(FloodRiskEngine::Exemption.count)).first || create(:exemption)
+      create(:exemption) if FloodRiskEngine::Exemption.count == 0
+
+      exemption = FloodRiskEngine::Exemption.offset(rand(FloodRiskEngine::Exemption.count)).first
 
       object.submit
 

--- a/spec/factories/partners.rb
+++ b/spec/factories/partners.rb
@@ -1,2 +1,0 @@
-FactoryGirl.define do
-end

--- a/spec/forms/admin/enrollment_exemptions/assistance_form_spec.rb
+++ b/spec/forms/admin/enrollment_exemptions/assistance_form_spec.rb
@@ -18,7 +18,7 @@ module Admin
         {
           form.params_key => {
             comment: comment,
-            assistance_mode: "full"
+            assistance_mode: "fully_assisted"
           }
         }
       end
@@ -61,7 +61,7 @@ module Admin
           end
 
           it "should save the status approved to the enrollment_exemption" do
-            expect(enrollment_exemption.reload.full?).to eq true
+            expect(enrollment_exemption.reload.fully_assisted?).to eq true
           end
         end
       end


### PR DESCRIPTION
Set the user on a new BO enrollment. 
This will ID the enrollment as BO generated 

Rename mode full to fully_assisted
Move enum to engine
Move updated_by_user_id migration to engine so dummy specs can run
Add AD field to export
Add EA area to export
PR fixes - use Presenter for more fields
Set user on enrollment when AD set
Take location fields from presenter
