### PR TITLE
RIP-277 Rename WaterBoundaryArea references to WaterManagementArea

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/EnvironmentAgency/flood-risk-engine
-  revision: f2b68768900bcd9253903090081d9dd9e8df1282
+  revision: 053219753fdd1869907c593ec9a7fd1b39c83ecc
   branch: develop
   specs:
     flood_risk_engine (0.0.1)
@@ -10,7 +10,7 @@ GIT
       dibber (~> 0.5)
       dotenv-rails (~> 2.1)
       ea-address_lookup (~> 0.3.0)
-      ea-area_lookup (~> 0.1.1)
+      ea-area_lookup (~> 0.2.1)
       finite_machine (~> 0.10)
       has_secure_token (~> 1.0.0)
       high_voltage (~> 3.0)
@@ -150,7 +150,7 @@ GEM
       activesupport (>= 4.2)
       nesty (~> 1.0)
       rest-client (~> 2.0.0.rc2)
-    ea-area_lookup (0.1.2)
+    ea-area_lookup (0.2.1)
       nokogiri (~> 1.6.8)
     easy_translate (0.5.0)
       json

--- a/app/presenters/enrollment_exemption_presenter.rb
+++ b/app/presenters/enrollment_exemption_presenter.rb
@@ -35,9 +35,9 @@ class EnrollmentExemptionPresenter < Presenter
 
   delegate :description, :grid_reference, to: :exemption_location, allow_nil: true
 
-  delegate :water_boundary_area, to: :exemption_location, allow_nil: true
+  delegate :water_management_area, to: :exemption_location, allow_nil: true
 
-  delegate :long_name, to: :water_boundary_area, prefix: true, allow_nil: true
+  delegate :long_name, to: :water_management_area, prefix: true, allow_nil: true
 
   def initialize(enrollment_exemption, view_context)
     @enrollment_exemption = enrollment_exemption
@@ -194,7 +194,7 @@ class EnrollmentExemptionPresenter < Presenter
       summary,
       grid_reference,
       description,
-      water_boundary_area_long_name
+      water_management_area_long_name
     ]
   end
 

--- a/app/queries/enrollment_exemption_search_query.rb
+++ b/app/queries/enrollment_exemption_search_query.rb
@@ -47,7 +47,7 @@ class EnrollmentExemptionSearchQuery
       where do
         (exemption.code =~ query.q) |
           (replace(enrollment.organisation.primary_address.postcode, " ", "") =~ query.fuzzy_without_whitespace) |
-          (replace(enrollment.exemption_location.grid_reference, " ", "") == query.without_whitespace) |
+          (replace(enrollment.exemption_location.grid_reference, " ", "") =~ query.without_whitespace) |
           (enrollment.organisation.name =~ query.fuzzy) |
           (enrollment.organisation.searchable_content =~ query.fuzzy) |
           (enrollment.reference_number.number =~ query.fuzzy) |

--- a/app/services/prepare_enrollment_export_report.rb
+++ b/app/services/prepare_enrollment_export_report.rb
@@ -50,7 +50,7 @@ class PrepareEnrollmentExportReport
       presenter.grid_reference,
       presenter.description,
       "#{exemption_location.easting},#{exemption_location.northing}",
-      presenter.water_boundary_area_long_name,
+      presenter.water_management_area_long_name,
       presenter.code,
       presenter.org_type,
       enrollment.correspondence_contact.full_name,
@@ -81,7 +81,7 @@ class PrepareEnrollmentExportReport
       "NGR",
       "Site description", # 10
       "Easting and Northing",
-      "EA area",
+      "Water management area",
       "Exemption code and description",
       "Business type",
       "Contact name",

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160712104613) do
+ActiveRecord::Schema.define(version: 201607111338823) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -150,13 +150,13 @@ ActiveRecord::Schema.define(version: 20160712104613) do
     t.string   "easting"
     t.string   "northing"
     t.string   "grid_reference"
-    t.datetime "created_at",             null: false
-    t.datetime "updated_at",             null: false
+    t.datetime "created_at",               null: false
+    t.datetime "updated_at",               null: false
     t.integer  "locatable_id"
     t.string   "locatable_type"
     t.text     "description"
     t.string   "dredging_length"
-    t.integer  "water_boundary_area_id"
+    t.integer  "water_management_area_id"
   end
 
   add_index "flood_risk_engine_locations", ["locatable_id", "locatable_type"], name: "by_locatable", using: :btree
@@ -194,7 +194,7 @@ ActiveRecord::Schema.define(version: 20160712104613) do
 
   add_index "flood_risk_engine_reference_numbers", ["number"], name: "index_flood_risk_engine_reference_numbers_on_number", using: :btree
 
-  create_table "flood_risk_engine_water_boundary_areas", force: :cascade do |t|
+  create_table "flood_risk_engine_water_management_areas", force: :cascade do |t|
     t.string   "code",       null: false
     t.string   "long_name",  null: false
     t.string   "short_name"
@@ -204,7 +204,7 @@ ActiveRecord::Schema.define(version: 20160712104613) do
     t.datetime "updated_at", null: false
   end
 
-  add_index "flood_risk_engine_water_boundary_areas", ["code"], name: "fre_water_boundary_areas_code", unique: true, using: :btree
+  add_index "flood_risk_engine_water_management_areas", ["code"], name: "fre_water_boundary_areas_code", unique: true, using: :btree
 
   create_table "roles", force: :cascade do |t|
     t.string   "name"


### PR DESCRIPTION
This is to align with business names to void confusion.
Rename the column 'EA area' in the report to 'Water management area'
