### PR TITLE
Add In Progress button in BO on View Exemption page - RIP-326

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/EnvironmentAgency/flood-risk-engine
-  revision: 053219753fdd1869907c593ec9a7fd1b39c83ecc
+  revision: 1b4d75f8100afaed8073b73329b8ad659ee6556d
   branch: develop
   specs:
     flood_risk_engine (0.0.1)

--- a/app/controllers/admin/enrollment_exemptions/in_progress_controller.rb
+++ b/app/controllers/admin/enrollment_exemptions/in_progress_controller.rb
@@ -1,0 +1,17 @@
+module Admin
+  module EnrollmentExemptions
+    class InProgressController < ChangeStatusBaseController
+
+      private
+
+      def authorize_action
+        authorize enrollment_exemption, :in_progress?
+      end
+
+      def form_class
+        InProgressForm
+      end
+
+    end
+  end
+end

--- a/app/controllers/admin/enrollments_controller.rb
+++ b/app/controllers/admin/enrollments_controller.rb
@@ -3,7 +3,11 @@ module Admin
 
     def new
       authorize FloodRiskEngine::Enrollment
-      redirect_to flood_risk_engine.new_enrollment_path
+
+      # This is used later  to ID the enrollment exemption as AD
+      bo_enrollment = FloodRiskEngine::Enrollment.create(updated_by_user_id: current_user.id)
+
+      redirect_to flood_risk_engine.enrollment_step_path(bo_enrollment, bo_enrollment.initial_step)
     end
 
     def edit

--- a/app/forms/admin/enrollment_exemptions/base_change_state_form.rb
+++ b/app/forms/admin/enrollment_exemptions/base_change_state_form.rb
@@ -7,8 +7,7 @@ module Admin
       include ActiveModel::Validations
       include Reform::Form::ActiveModel
 
-      require_relative "concerns/form_status_tag"
-      include FormStatusTag
+      include Concerns::FormStatusTag
 
       def self.t(locale, args = {})
         I18n.t locale, args.merge(scope: locale_key)

--- a/app/forms/admin/enrollment_exemptions/concerns/form_status_tag.rb
+++ b/app/forms/admin/enrollment_exemptions/concerns/form_status_tag.rb
@@ -1,22 +1,26 @@
 module Admin
   module EnrollmentExemptions
-    module FormStatusTag
+    module Concerns
+      module FormStatusTag
 
-      include StatusTag
+        include Reform::Form::Module
 
-      def status_tag
-        super(enrollment_exemption.status, status_label)
+        include StatusTag
+
+        def status_tag
+          super(enrollment_exemption.status, status_label)
+        end
+
+        def status_label
+          return unless enrollment_exemption.status.present?
+          I18n.t(enrollment_exemption.status, scope: "admin.status_label")
+        end
+
+        def enrollment_exemption
+          raise "Instance method `#{__method__}` must be defined in #{self.class.name}"
+        end
+
       end
-
-      def status_label
-        return unless enrollment_exemption.status.present?
-        I18n.t(enrollment_exemption.status, scope: "admin.status_label")
-      end
-
-      def enrollment_exemption
-        raise "Instance method `#{__method__}` must be defined in #{self.class.name}"
-      end
-
     end
   end
 end

--- a/app/forms/admin/enrollment_exemptions/in_progress_form.rb
+++ b/app/forms/admin/enrollment_exemptions/in_progress_form.rb
@@ -1,0 +1,28 @@
+module Admin
+  module EnrollmentExemptions
+    class InProgressForm < BaseChangeStateForm
+
+      def params_key
+        :admin_enrollment_exemptions_in_progress
+      end
+
+      def self.locale_key
+        "admin.enrollment_exemptions.in_progress.new"
+      end
+
+      # create_comment expects content via comment property but we've no comment panel and nothing else to say
+      def comment
+      end
+
+      def save
+        enrollment_exemption.accept_reject_decision_user_id = user.id
+        enrollment_exemption.being_processed!
+
+        super
+
+        create_comment("Status changed to In Progress")
+      end
+
+    end
+  end
+end

--- a/app/policies/flood_risk_engine/enrollment_exemption_policy.rb
+++ b/app/policies/flood_risk_engine/enrollment_exemption_policy.rb
@@ -35,6 +35,7 @@ module FloodRiskEngine
     def process?
       user_can_edit_and_status? :pending
     end
+    alias in_progress? process?
 
     def withdraw?
       user_can_edit_and_status? :pending, :being_processed

--- a/app/presenters/enrollment_exemption_presenter.rb
+++ b/app/presenters/enrollment_exemption_presenter.rb
@@ -111,6 +111,12 @@ class EnrollmentExemptionPresenter < Presenter
     6
   end
 
+  # For partnerships we sometimes need ALL names not just the first
+  def organisation_details
+    return blank_value unless organisation
+    organisation.partnership? ? partner_names : organisation.name
+  end
+
   def organisation_name
     return blank_value unless organisation
     organisation.partnership? ? first_partner_name : organisation.name
@@ -125,6 +131,10 @@ class EnrollmentExemptionPresenter < Presenter
   def address
     return unless organisation
     organisation.partnership? ? first_partner_address : organisation.primary_address
+  end
+
+  def partner_names
+    organisation.partners.collect { |p| p.contact.full_name }.join(",")
   end
 
   def first_partner_name

--- a/app/services/prepare_enrollment_export_report.rb
+++ b/app/services/prepare_enrollment_export_report.rb
@@ -56,7 +56,7 @@ class PrepareEnrollmentExportReport
       enrollment.correspondence_contact.full_name,
       enrollment.correspondence_contact.email_address,
       enrollment.correspondence_contact.telephone_number,
-      presenter.organisation_name,
+      presenter.organisation_details,
       comments(enrollment_exemption),
       linkage_url
     ]

--- a/app/views/admin/enrollment_exemptions/in_progress/new.html.erb
+++ b/app/views/admin/enrollment_exemptions/in_progress/new.html.erb
@@ -1,0 +1,42 @@
+<div class="container-fluid">
+  <div class="row">
+    <div class="col-xs-12 col-sm-10">
+      <h1><%= t(".title", reference: form.reference_number) %></h1>
+
+      <div class="row">
+        <div class="col-md-12">
+          <div class="panel panel-default">
+            <div class="panel-heading panel-title">
+              <%= t(".panel_title") %>
+            </div>
+
+            <div class="panel-body">
+              <%= simple_form_for form,
+                                  url: admin_enrollment_exemption_in_progress_index_path(form.enrollment_exemption),
+                                  html: { method: :post } do |f| %>
+                <div class="table-responsive">
+                  <table class="table table-bordered">
+                    <tbody>
+                    <tr>
+                      <th class="col-md-2"><%= t(".table_headings.operator") %></th>
+                      <td class="col-md-10"><%= form.organisation_name %></td>
+                    </tr>
+                    <tr>
+                      <th class="col-md-2"><%= t(".table_headings.exemption_code") %></th>
+                      <td class="col-md-10"><%= form.exemption.code %></td>
+                    </tr>
+                    </tbody>
+                  </table>
+                </div>
+                <%= f.button :submit, t(".submit"), class: 'btn btn-primary' %>
+              <% end %>
+            </div>
+          </div>
+        </div>
+      </div>
+      <%= link_to glyphicon_tag(:triangle_left, text: t("cancel_go_back")),
+                  [:admin, form.enrollment_exemption],
+                  class: "ignore-visited" %>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/enrollment_exemptions/show/_actions.html.erb
+++ b/app/views/admin/enrollment_exemptions/show/_actions.html.erb
@@ -46,6 +46,15 @@
       </p>
     <% end %>
 
+    <% if policy(presenter.enrollment_exemption).in_progress? %>
+      <p>
+        <%= link_to t(".in_progress"),
+                    new_admin_enrollment_exemption_in_progress_path(presenter.enrollment_exemption),
+                    class: "btn btn-warning",
+                    role: 'button' %>
+      </p>
+    <% end %>
+
     <% if policy(presenter.enrollment_exemption).approve? %>
       <p>
         <%= link_to t(".approve"),

--- a/config/locales/admin/enrollment_exemptions/in_progress.yml
+++ b/config/locales/admin/enrollment_exemptions/in_progress.yml
@@ -1,0 +1,11 @@
+en:
+  admin:
+    enrollment_exemptions:
+      in_progress:
+        new:
+          title: Change status of %{reference} to In Progress
+          panel_title: Exemption
+          table_headings:
+            operator: Operator
+            exemption_code: Exemption number
+          submit: Confirm In Progress status

--- a/config/locales/admin/enrollment_exemptions/show/enrollment_exemptions.en.yml
+++ b/config/locales/admin/enrollment_exemptions/show/enrollment_exemptions.en.yml
@@ -11,6 +11,7 @@ en:
           change_ad: Change AD classification
           withdraw: Withdraw
           deregister: Deregister
+          in_progress: In Progress
           reject: Reject
           approve: Approve
           resend_approval_email: Reissue approval email

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,42 +23,41 @@ Rails.application.routes.draw do
     end
     resources :enrollments, only: [:index, :show, :edit, :update, :new]
     resources :enrollment_exemptions, only: [:index, :show] do
-      resources(
-        :deregister,
-        only: [:new, :create],
-        path_names: {new: ""},
-        controller: "enrollment_exemptions/deregister"
-      )
-      resources(
-        :reject,
-        only: [:new, :create],
-        path_names: {new: ""},
-        controller: "enrollment_exemptions/reject"
-      )
-      resources(
-        :approve,
-        only: [:new, :create],
-        path_names: {new: ""},
-        controller: "enrollment_exemptions/approve"
-      )
-      resources(
-        :resend_approval_email,
-        only: [:new, :create],
-        path_names: {new: ""},
-        controller: "enrollment_exemptions/resend_approval_email"
-      )
-      resources(
-        :change_status,
-        only: [:new, :create],
-        path_names: {new: ""},
-        controller: "enrollment_exemptions/change_status"
-      )
-      resources(
-        :withdraw,
-        only: [:new, :create],
-        path_names: {new: ""},
-        controller: "enrollment_exemptions/withdraw"
-      )
+
+      scope path_names: { new: "" } do
+        resources(
+          :deregister,
+          only: [:new, :create],
+          controller: "enrollment_exemptions/deregister"
+        )
+        resources(
+          :reject,
+          only: [:new, :create],
+          controller: "enrollment_exemptions/reject"
+        )
+        resources(
+          :approve,
+          only: [:new, :create],
+          controller: "enrollment_exemptions/approve"
+        )
+        resources(
+          :resend_approval_email,
+          only: [:new, :create],
+          controller: "enrollment_exemptions/resend_approval_email"
+        )
+        resources(
+          :change_status,
+          only: [:new, :create],
+          controller: "enrollment_exemptions/change_status"
+        )
+        resources(
+          :withdraw,
+          only: [:new, :create],
+          controller: "enrollment_exemptions/withdraw"
+        )
+
+        resources :in_progress, only: [:new, :create], controller: "enrollment_exemptions/in_progress"
+      end
 
       resource :assistance, only: [:edit, :update], controller: "enrollment_exemptions/assistance"
 

--- a/spec/controllers/admin/enrollments_controller_spec.rb
+++ b/spec/controllers/admin/enrollments_controller_spec.rb
@@ -39,9 +39,9 @@ module Admin
         get :new
       end
 
-      it "should redirect to engine's new enrollment path" do
+      it "should redirect to engine's initial step path" do
         expect(response).to be_redirect
-        expect(response.location).to match("enrollments/new")
+        expect(response.location).to match("steps/add_exemptions")
       end
     end
 

--- a/spec/features/admin/change_enrollment_assistance_mode_spec.rb
+++ b/spec/features/admin/change_enrollment_assistance_mode_spec.rb
@@ -31,6 +31,13 @@ RSpec.feature "Change enrollment's assistance mode" do
     expect(page).to have_select("admin_enrollment_exemptions_assistance_assistance_mode", selected: mode_text)
   end
 
+  scenario "The form displays previously set AD classification" do
+    mode_text = EnrollmentExemptionPresenter.assistance_mode_text enrollment_exemption.assistance_mode
+
+    expect(page).to have_css("h1:first", text: I18n.t(".edit.title", scope: scope))
+    expect(page).to have_select("admin_enrollment_exemptions_assistance_assistance_mode", selected: mode_text)
+  end
+
   EnrollmentExemptionPresenter.assistance_modes_map.each do |mode_text, mode_name|
     scenario "Change enrollment mode to '#{mode_text}'" do
       expect(page).to have_css("h1:first", text: I18n.t(".edit.title", scope: scope))
@@ -47,8 +54,6 @@ RSpec.feature "Change enrollment's assistance mode" do
       expect(enrollment_exemption.assistance_mode).to eq mode_name
 
       display_mode = EnrollmentExemptionPresenter.assistance_mode_text(enrollment_exemption.assistance_mode)
-
-      # redirect_to [:admin, enrollment_exemption], notice: t(".notice", mode: display_mode)
 
       msg = I18n.t(".update.notice", scope: scope, mode: display_mode)
 

--- a/spec/features/admin/new_enrollment_spec.rb
+++ b/spec/features/admin/new_enrollment_spec.rb
@@ -1,0 +1,18 @@
+RSpec.feature "Change enrollment's assistance mode" do
+  let(:user) { create(:user).tap { |u| u.add_role :system } }
+
+  let(:enrollment) { create :confirmed }
+  let(:enrollment_exemption) { enrollment.enrollment_exemptions.first }
+
+  before(:each) do
+    login_as user
+
+    visit admin_enrollment_exemption_path(enrollment_exemption)
+  end
+
+  scenario "The user should be set on a new enrollment" do
+    visit new_admin_enrollment_path
+
+    expect(FloodRiskEngine::Enrollment.last.updated_by_user_id).to eq(user.id)
+  end
+end

--- a/spec/forms/admin/enrollment_exemptions/in_progress_form_spec.rb
+++ b/spec/forms/admin/enrollment_exemptions/in_progress_form_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+require "shoulda/matchers"
+
+module Admin
+  module EnrollmentExemptions
+    RSpec.describe InProgressForm, type: :form do
+      let(:user) { FactoryGirl.create(:user) }
+      let(:enrollment_exemption) { FactoryGirl.create(:enrollment_exemption) }
+      let(:form) { described_class.new(enrollment_exemption, user) }
+
+      let(:params) do
+        { form.params_key => {} }
+      end
+
+      describe "#validate" do
+        it "should return true as no params to validate" do
+          expect(form.validate(params)).to be(true)
+        end
+      end
+
+      describe "#save" do
+        it "should add a comment" do
+          expect { form.save }.to change { FloodRiskEngine::Comment.count }.by(1)
+        end
+
+        context "after save" do
+          before {
+            expect(enrollment_exemption.being_processed?).to eq(false)
+            form.save
+          }
+
+          it "should save the comment to a Comment model" do
+            expect(FloodRiskEngine::Comment.last.event).to eq("Status changed to In Progress")
+          end
+
+          it "should set the User to the current logged in BO user" do
+            expect(enrollment_exemption.accept_reject_decision_user).to eq user
+            expect(enrollment_exemption.accept_reject_decision_user_id).to eq user.id
+          end
+
+          it "should save the status in_progressd to the enrollment_exemption" do
+            expect(enrollment_exemption.reload.being_processed?).to eq(true)
+          end
+        end
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RIP-326

Implement controller and form for updating status to In Progress
Fix issues with auto loading of concern/modules in Reform forms
Change export so all partner names displayed instead of just first
Reinstate changes to enrollment controller
