### PR TITLE
Fix translation error in form and deregister status button colour

### DIFF
--- a/app/forms/admin/enrollment_exemptions/deregister_form.rb
+++ b/app/forms/admin/enrollment_exemptions/deregister_form.rb
@@ -23,9 +23,9 @@ module Admin
         inclusion: {
           in: reasons.collect(&:to_s),
           message: t(
-            ".errors.status.inclusion",
-            reasons: reasons.join(
-              t(".errors.status.last_word_connector")
+            ".errors.deregister_reason.inclusion",
+            reasons: reasons.collect { |r| "'#{r.to_s.humanize}'" }.join(
+              t(".errors.deregister_reason.last_word_connector")
             )
           )
         }

--- a/app/presenters/concerns/status_tag.rb
+++ b/app/presenters/concerns/status_tag.rb
@@ -9,7 +9,7 @@ module StatusTag
     rejected: "danger",
     expired:  "danger",
     withdrawn: "danger",
-    deregistered: "info"
+    deregistered: "warning"
   }.freeze
 
   def status_tag_css_class(status)

--- a/config/locales/admin/enrollment_exemptions/deregister/new.en.yml
+++ b/config/locales/admin/enrollment_exemptions/deregister/new.en.yml
@@ -19,4 +19,3 @@ en:
             deregister_reason:
               inclusion: "The status must be one of: %{reasons}"
               last_word_connector: " or "
-


### PR DESCRIPTION
The translation call in a form error was out of date, the status colour needed to match the action button colour
