### PR TITLE
RIP-334 Times shown an hour off

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -31,7 +31,7 @@ module FloodRiskBackOffice
 
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
-    # config.time_zone = 'Central Time (US & Canada)'
+    config.time_zone = 'London'
 
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     config.i18n.load_path += Dir[Rails.root.join('config/locales/**/*.{rb,yml}').to_s]


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RIP-334

Set the Rails application time zone to convert dates (stored in UTC)
in the database to London/UK time automatically in views.
