### PR TITLE
RIP-356 Add a configurable session timeout

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,7 +16,9 @@ class User < ActiveRecord::Base
          :lockable,
          :invitable,
          :recoverable,
-         :session_limitable
+         :session_limitable,
+         :timeoutable,
+         timeout_in: Rails.application.secrets.session_timeout_minutes.minutes
 
   validate :password_meets_minimum_requirements
   validates :email, length: { maximum: 255 }

--- a/config/locales/devise.security_extension.en.yml
+++ b/config/locales/devise.security_extension.en.yml
@@ -12,5 +12,10 @@ en:
       updated: "Your new password is saved."
       change_required: "Your password is expired. Please renew your password."
     failure:
-      session_limited: 'Your login credentials were used in another browser. Please sign in again to continue in this browser.'
+      session_limited: >
+        Your login credentials were used in another browser. You need to sign in again to
+        continue in this browser.
+        If this message is unexpected, please change your password using the
+        'Reset your password' link.
+
       expired: 'Your account has expired due to inactivity. Please contact the site administrator.'

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -17,6 +17,7 @@ defaults: &defaults
   aws_access_key_id: <%= ENV['AWS_ACCESS_KEY_ID'] %>
   aws_secret_access_key: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
   aws_region: <%= ENV['AWS_REGION'] || 'eu-west-1' %>
+  session_timeout_minutes: <%= ENV.fetch("SESSION_TIMEOUT_MINUTES", 480).to_i %>
 
 development:
   <<: *defaults


### PR DESCRIPTION
Add a session timeout which can be configured by a SESSION_TIMEOUT_MINUTES environment variable, defaulting to 8 hours.
