### PR TITLE
Add OS places notice and T&C's to service

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem "dotenv-rails", "~> 2.1.1"
 
 gem "flood_risk_engine",
     git: "https://github.com/EnvironmentAgency/flood-risk-engine",
-    branch: "master"
+    tag: "v1.0.2"
 
 gem "govuk_admin_template", "~> 4.2.0"
 gem "govuk_elements_rails", "~> 1.2.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/EnvironmentAgency/flood-risk-engine
-  revision: 16fbde254277aec1513bca15de2e9e87d0d254b5
-  branch: master
+  revision: c2e2f5845de94480e1b2f85010ce6dbc72264c9e
+  tag: v1.0.2
   specs:
-    flood_risk_engine (1.0.1)
+    flood_risk_engine (1.0.2)
       activerecord-session_store (~> 1.0)
       airbrake (~> 5.3.0)
       airbrake-ruby (~> 1.3.2)
@@ -107,7 +107,7 @@ GEM
     cliver (0.3.2)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
-    concurrent-ruby (1.0.2)
+    concurrent-ruby (1.0.3)
     daemons (1.2.3)
     database_cleaner (1.5.3)
     debug_inspector (0.0.2)
@@ -170,7 +170,7 @@ GEM
     fuubar (2.0.0)
       rspec (~> 3.0)
       ruby-progressbar (~> 1.4)
-    globalid (0.3.6)
+    globalid (0.3.7)
       activesupport (>= 4.1.0)
     govuk_admin_template (4.2.0)
       bootstrap-sass (= 3.3.5.1)
@@ -220,13 +220,12 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
     mini_portile2 (2.1.0)
-    minitest (5.9.0)
+    minitest (5.10.1)
     multi_json (1.12.1)
     nesty (1.0.2)
     netrc (0.11.0)
-    nokogiri (1.6.8)
+    nokogiri (1.6.8.1)
       mini_portile2 (~> 2.1.0)
-      pkg-config (~> 1.1.7)
     orm_adapter (0.5.0)
     os_map_ref (0.4.1)
     paper_trail (5.1.1)
@@ -240,7 +239,6 @@ GEM
       rake (>= 0.8.1)
     pg (0.18.4)
     phonelib (0.6.8)
-    pkg-config (1.1.7)
     poltergeist (1.9.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
@@ -253,7 +251,7 @@ GEM
       activesupport (>= 3.0.0)
     quiet_assets (1.1.0)
       railties (>= 3.1, < 5.0)
-    rack (1.6.4)
+    rack (1.6.5)
     rack-mini-profiler (0.10.1)
       rack (>= 1.2.0)
     rack-test (0.6.3)
@@ -288,7 +286,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rainbow (2.1.0)
-    rake (11.2.2)
+    rake (12.0.0)
     reform (2.1.0)
       disposable (>= 0.2.2, < 0.3.0)
       representable (>= 2.4.0, < 3.1.0)
@@ -360,10 +358,10 @@ GEM
     spring (1.7.1)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
-    sprockets (3.6.3)
+    sprockets (3.7.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
-    sprockets-rails (3.1.1)
+    sprockets-rails (3.2.0)
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
@@ -380,7 +378,7 @@ GEM
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
       rack (>= 1, < 3)
-    thor (0.19.1)
+    thor (0.19.4)
     thread (0.2.2)
     thread_safe (0.3.5)
     tilt (2.0.4)
@@ -477,4 +475,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.12.5
+   1.13.6


### PR DESCRIPTION
The actual changes have been done in the [Flood risk engine](https://github.com/EnvironmentAgency/flood-risk-engine/) but this change brings in the version of the engine which includes it.