### PR TITLE
Update EA references after org name change

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem "devise_security_extension", "~> 0.10.0"
 gem "dotenv-rails", "~> 2.1.1"
 
 gem "flood_risk_engine",
-    git: "https://github.com/EnvironmentAgency/flood-risk-engine",
+    git: "https://github.com/DEFRA/flood-risk-engine",
     tag: "v1.0.2"
 
 gem "govuk_admin_template", "~> 4.2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: https://github.com/EnvironmentAgency/flood-risk-engine
+  remote: https://github.com/DEFRA/flood-risk-engine
   revision: c2e2f5845de94480e1b2f85010ce6dbc72264c9e
   tag: v1.0.2
   specs:
@@ -74,7 +74,7 @@ GEM
     airbrake (5.3.0)
       airbrake-ruby (~> 1.3)
     airbrake-ruby (1.3.2)
-    arel (6.0.3)
+    arel (6.0.4)
     ast (2.2.0)
     autoprefixer-rails (6.3.6.2)
       execjs
@@ -91,7 +91,7 @@ GEM
     bootstrap-sass (3.3.5.1)
       autoprefixer-rails (>= 5.0.0.1)
       sass (>= 3.3.0)
-    builder (3.2.2)
+    builder (3.2.3)
     bullet (5.1.1)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.10.0)
@@ -107,7 +107,7 @@ GEM
     cliver (0.3.2)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
-    concurrent-ruby (1.0.3)
+    concurrent-ruby (1.0.4)
     daemons (1.2.3)
     database_cleaner (1.5.3)
     debug_inspector (0.0.2)
@@ -137,10 +137,10 @@ GEM
     docile (1.1.5)
     domain_name (0.5.20161129)
       unf (>= 0.0.5, < 1.0.0)
-    dotenv (2.1.1)
-    dotenv-rails (2.1.1)
-      dotenv (= 2.1.1)
-      railties (>= 4.0, < 5.1)
+    dotenv (2.1.2)
+    dotenv-rails (2.1.2)
+      dotenv (= 2.1.2)
+      railties (>= 3.2, < 5.1)
     ea-address_lookup (0.3.3)
       activesupport (>= 4.2)
       nesty (~> 1.0)
@@ -206,7 +206,7 @@ GEM
     jquery-rails (3.1.4)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
-    json (1.8.3)
+    json (1.8.6)
     kaminari (0.17.0)
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
@@ -238,7 +238,7 @@ GEM
       rack
       rake (>= 0.8.1)
     pg (0.18.4)
-    phonelib (0.6.8)
+    phonelib (0.6.9)
     poltergeist (1.9.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
@@ -269,9 +269,9 @@ GEM
       sprockets-rails
     rails-deprecated_sanitizer (1.0.3)
       activesupport (>= 4.2.0.alpha)
-    rails-dom-testing (1.0.7)
+    rails-dom-testing (1.0.8)
       activesupport (>= 4.2.0.beta, < 5.0)
-      nokogiri (~> 1.6.0)
+      nokogiri (~> 1.6)
       rails-deprecated_sanitizer (>= 1.0.1)
     rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Flood Risk Back Office
 
-[![CircleCI](https://circleci.com/gh/EnvironmentAgency/flood-risk-back-office.svg?style=svg&circle-token=690d1e5fe311a8bbc2b80af8bb70a0d0876b072e)](https://circleci.com/gh/EnvironmentAgency/flood-risk-back-office)
+[![CircleCI](https://circleci.com/gh/DEFRA/flood-risk-back-office.svg?style=svg&circle-token=690d1e5fe311a8bbc2b80af8bb70a0d0876b072e)](https://circleci.com/gh/DEFRA/flood-risk-back-office)
 
 A Ruby on Rails application delivering the [Flood risk activity exemptions service](https://register-flood-risk-exemption.service.gov.uk).
 
-This is a thin, host application which mounts and provides styling for the [flood_risk_engine](https://github.com/EnvironmentAgency/flood-risk-engine) rails engine, and adds functionality specific to internal users. The engine is responsible for the service implementation.
+This is a thin, host application which mounts and provides styling for the [flood_risk_engine](https://github.com/DEFRA/flood-risk-engine) rails engine, and adds functionality specific to internal users. The engine is responsible for the service implementation.
 
 ## Prerequisites
 
@@ -21,7 +21,7 @@ Please make sure the following are installed:
 Clone the repository and install its gem dependencies
 
 ```bash
-git clone https://github.com/EnvironmentAgency/flood-risk-back-office.git
+git clone https://github.com/DEFRA/flood-risk-back-office.git
 cd flood-risk-back-office
 bundle
 ```
@@ -117,7 +117,7 @@ So for example the login for the data user is
 
 ## Tests
 
-We use [RSpec](http://rspec.info/) and the project contains both feature and unit tests which focus on the functionality added specifically for internal users. Unit testing for the application process is generally done in [flood _risk_engine](https://github.com/EnvironmentAgency/flood-risk-engine) and acceptance tests in [Flood risk acceptance tests](https://github.com/EnvironmentAgency/flood-risk-acceptance-tests).
+We use [RSpec](http://rspec.info/) and the project contains both feature and unit tests which focus on the functionality added specifically for internal users. Unit testing for the application process is generally done in [flood _risk_engine](https://github.com/DEFRA/flood-risk-engine) and acceptance tests in [Flood risk acceptance tests](https://github.com/DEFRA/flood-risk-acceptance-tests).
 
 To run the rspec test suite
 
@@ -127,7 +127,7 @@ bundle exec rake
 
 ## Quality and conventions
 
-The project is linked to [Circle CI](https://circleci.com/gh/EnvironmentAgency/flood-risk-back-office) and all pushes to the **GitHub** are automatically checked.
+The project is linked to [Circle CI](https://circleci.com/gh/DEFRA/flood-risk-back-office) and all pushes to the **GitHub** are automatically checked.
 
 The checks include running all tests plus **Rubocop**, but also tools like [HTLMHint](https://github.com/yaniswang/HTMLHint) and [i18n-tasks](https://github.com/glebm/i18n-tasks). Check the `circle.yml` for full details, specifically the `test:pre` section.
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,7 +19,7 @@
   # helpers such as this navbar.
   #
   # A better solution is outlined here:
-  # https://github.com/EnvironmentAgency/flood-risk-engine/issues/200
+  # https://github.com/DEFRA/flood-risk-engine/issues/200
   render 'layouts/navbar' unless controller.class.ancestors.include?(FloodRiskEngine::ApplicationController)
 -%>
 

--- a/config/locales/pages.en.yml
+++ b/config/locales/pages.en.yml
@@ -3,7 +3,7 @@ en:
     version:
       heading: Flood Risk Back Office
       app_version: Application Version
-      repository_url: 'https://github.com/EnvironmentAgency/flood_risk_back_office/commit/%{sha}'
+      repository_url: 'https://github.com/DEFRA/flood_risk_back_office/commit/%{sha}'
       app_version: 'Application version:'
       commit: 'Commit hash:'
       render_time: 'Page rendered at:'

--- a/config/locales/views.yml
+++ b/config/locales/views.yml
@@ -12,7 +12,7 @@ en:
       title: "Flood Risk Admin System"
   pages:
     version:
-      back_office_repository_url: 'https://github.com/EnvironmentAgency/flood-risk-back-office/commit/%{sha}'
+      back_office_repository_url: 'https://github.com/DEFRA/flood-risk-back-office/commit/%{sha}'
       back_office_heading: GOV.UK Flood Risk admin system
   admin:
     enrollments:


### PR DESCRIPTION
The Environment Agency organisation on GitHub recently changed its name to DEFRA. This has resulted in a change to all the urls for all our repos. This changes updates any references to the old repo url's for example

- in repo status badges
- links to other projects in the README
- library links, for example in the `Gemfile`