### PR TITLE
Remove heroku from repo

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -87,6 +87,4 @@ group :production do
   # Use Passenger as our web-server/app-server (e.g. on AWS via Upstart, Heroku
   # via Procfile)	  # via Procfile)
   gem "passenger", "~> 5.0", ">= 5.0.30", require: "phusion_passenger/rack_handler"
-  # Useful if deploying to Heroku
-  gem "rails_12factor", "~> 0.0.3"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -257,11 +257,6 @@ GEM
       rails-deprecated_sanitizer (>= 1.0.1)
     rails-html-sanitizer (1.0.4)
       loofah (~> 2.2, >= 2.2.2)
-    rails_12factor (0.0.3)
-      rails_serve_static_assets
-      rails_stdout_logging
-    rails_serve_static_assets (0.0.5)
-    rails_stdout_logging (0.0.5)
     railties (4.2.11.1)
       actionpack (= 4.2.11.1)
       activesupport (= 4.2.11.1)
@@ -417,7 +412,6 @@ DEPENDENCIES
   pundit (~> 1.1.0)
   quiet_assets (~> 1.1.0)
   rails (~> 4.2)
-  rails_12factor (~> 0.0.3)
   rolify (~> 5.1.0)
   rspec-activemodel-mocks (~> 1.0.3)
   rspec-rails (~> 3.4.2)

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: bundle exec passenger start -p $PORT --max-pool-size 3

--- a/README.md
+++ b/README.md
@@ -44,19 +44,6 @@ bundle exec rake db:seed
 
 Add `RAILS_ENV=test` to the commands when preparing the test database.
 
-#### Seeding in Heroku
-
-To seed on Heroku where the environment is PRODUCTION, connect to a non-visitor and non-office network and run
-
-```bash
-heroku run bash -a [heroku_app_name]
-bundle exec rails c
-require './db/seeds/development.rb'
-FloodRiskEngine::Engine.load_seed # loads exemptions seed data
-exit
-exit
-```
-
 ## Running the app
 
 To start the service locally run


### PR DESCRIPTION
When the app was first built there were no environments in which to deploy it. So the team used Heroku whilst they waited for them to become available.

The heroku apps are no longer used and hence there is no longer a need to maintain anything related to Heroku in the project.