### PR TITLE
Integrate CI tools with repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,43 @@
+env:
+  global:
+    - CC_TEST_REPORTER_ID=979aae828b3d597b1901b0e990c4f6b47613581f98307aef9a2c9da4cb5a35f2
+
+language: ruby
+rvm: 2.3.1
+cache: bundler
+
+addons:
+-  postgresql: "9.4"
+
+# Travis CI clones repositories to a depth of 50 commits, which is only really
+# useful if you are performing git operations.
+# https://docs.travis-ci.com/user/customizing-the-build/#Git-Clone-Depth
+git:
+  depth: 3
+
+before_install:
+  - export TZ=UTC
+  - gem install -v 1.17.3 bundler --no-document
+
+before_script:
+  # Setup to support the CodeClimate test coverage submission
+  # As per CodeClimate's documentation, they suggest only running
+  # ./cc-test-reporter commands on travis-ci push builds only. Hence we wrap all
+  # the codeclimate test coverage related commands in a check that tests if we
+  # are in a pull request or not.
+  - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter; fi
+  - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then chmod +x ./cc-test-reporter; fi
+  - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then ./cc-test-reporter before-build; fi
+  # Run rubocop. It's installed as a dependency (hence no install step) as this
+  # allows projects to control the version they are using (rather than getting)
+  # surprise build failures.
+  - bundle exec rubocop
+  # Replace database.yml with database.travis.yml (but leave filename as
+  # database.yml). database.travis.yml is the config needed for Travis, and it
+  # needs to be in place before we run the migrations.
+  - cp config/database.travis.yml config/database.yml
+  - RAILS_ENV=test bundle exec rake db:create --trace
+  - RAILS_ENV=test bundle exec rake db:migrate --trace
+
+after_script:
+  - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT; fi

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Flood risk back office
 
+[![Build Status](https://travis-ci.com/DEFRA/flood-risk-back-office.svg?branch=master)](https://travis-ci.com/DEFRA/flood-risk-back-office)
+[![Maintainability](https://api.codeclimate.com/v1/badges/873dadc919fb21ab073c/maintainability)](https://codeclimate.com/github/DEFRA/flood-risk-back-office/maintainability)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/873dadc919fb21ab073c/test_coverage)](https://codeclimate.com/github/DEFRA/flood-risk-back-office/test_coverage)
+[![security](https://hakiri.io/github/DEFRA/flood-risk-back-office/master.svg)](https://hakiri.io/github/DEFRA/flood-risk-back-office/master)
+[![Licence](https://img.shields.io/badge/Licence-OGLv3-blue.svg)](http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3)
+
 A Ruby on Rails application delivering the [Flood risk activity exemptions service](https://register-flood-risk-exemption.service.gov.uk).
 
 This is a thin, host application which mounts and provides styling for the [flood_risk_engine](https://github.com/DEFRA/flood-risk-engine) rails engine, and adds functionality specific to internal users. The engine is responsible for the service implementation.

--- a/config/database.travis.yml
+++ b/config/database.travis.yml
@@ -1,0 +1,4 @@
+test:
+  adapter: postgresql
+  database: travis_ci_test
+  username: postgres


### PR DESCRIPTION
Now we have made the repository public there are a number of CI tools we can integrate

- [Codeclimate](https://codeclimate.com)
- [Hakiri](https://hakiri.io/)
- [Travis CI](https://travis-ci.com)

This change covers the updates necessary to integrate with these services, and badges! 😀