### PR TITLE
Inherit engine styles

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -1,4 +1,8 @@
 /*
+ *= require flood_risk_engine/application
+*/
+
+/*
  * This is a manifest file that'll be compiled into application.css, which will include all the files
  * listed below.
  *


### PR DESCRIPTION
Include the application.scss from the engine. This lets us use shared styles like the privacy policy date styling.