### PR TITLE
Migrate area lookup to defra-ruby-area

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,16 @@
 GIT
   remote: https://github.com/DEFRA/flood-risk-engine
-  revision: 99a53262ca3ff6fcfd78daa814273d555cdd7e17
+  revision: ce681097deb10f5c2ebdb762d4ee66375dea7e50
   branch: master
   specs:
     flood_risk_engine (1.0.2)
       activerecord-session_store (~> 1.0)
       airbrake (~> 5.3.0)
       airbrake-ruby (~> 1.3.2)
+      defra_ruby_area
       dibber (~> 0.5)
       dotenv-rails (~> 2.1)
       ea-address_lookup (~> 0.3.0)
-      ea-area_lookup (~> 0.2.2)
       finite_machine (~> 0.11.3)
       has_secure_token (~> 1.0.0)
       high_voltage (~> 3.0)
@@ -112,6 +112,9 @@ GEM
     database_cleaner (1.5.3)
     declarative (0.0.10)
     declarative-option (0.1.0)
+    defra_ruby_area (1.1.0)
+      nokogiri (~> 1.10.3)
+      rest-client (~> 2.0)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     devise (3.5.10)
@@ -144,8 +147,6 @@ GEM
       activesupport (>= 4.2)
       nesty (~> 1.0)
       rest-client (~> 2.0.0.rc2)
-    ea-area_lookup (0.2.2)
-      nokogiri (~> 1.7)
     email_spec (2.1.2)
       htmlentities (~> 4.3.3)
       launchy (~> 2.1)

--- a/config/initializers/area_lookup.rb
+++ b/config/initializers/area_lookup.rb
@@ -1,3 +1,0 @@
-EA::AreaLookup.configure do |config|
-  # config.administrative_area_api_url = ?
-end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-484

We have switched the FRAE service to use the gem [defra-ruby-area](https://github.com/DEFRA/defra-ruby-area) instead of [ea-area_lookup](https://github.com/DEFRA/ea-area_lookup). This means we need to update the engine (where the gem is added as a dependency and the logic sits) and remove the old gem's initializer (the new gem doesn't need one).