### PR TITLE
Add scheduled task to add missing Area information

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,9 @@ AWS_MANUAL_EXPORT_ACCESS_KEY_ID=<key_id>
 AWS_MANUAL_EXPORT_SECRET_ACCESS_KEY=<secret_key>
 AWS_MANUAL_EXPORT_BUCKET=<bucket_name>
 
+# Minutes the EA area lookup job should run for
+EA_AREA_LOOKUP_RUN_FOR=60
+
 # Default is to write to Filesystem and AWS, with read from AWS
 # Comment this out to enable AWS
 EXPORT_USE_FILESYSTEM_NOT_AWS_S3=true

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,6 +33,9 @@ module FloodRiskBackOffice
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
     config.time_zone = 'London'
 
+    # Minutes the EA area lookup job should run for
+    config.ea_area_lookup_run_for = ENV["EA_AREA_LOOKUP_RUN_FOR"] || 60
+
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     config.i18n.load_path += Dir[Rails.root.join('config/locales/**/*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -18,3 +18,16 @@
 # end
 
 # Learn more: http://github.com/javan/whenever
+
+log_output_path = ENV["EXPORT_SERVICE_CRON_LOG_OUTPUT_PATH"] || "/srv/ruby/flood-risk-back-office/shared/log/"
+set :output, File.join(log_output_path, "whenever_cron.log")
+set :job_template, "/bin/bash -l -c 'eval \"$(rbenv init -)\" && :job'"
+
+# Only one of the AWS app servers has a role of "db"
+# see https://gitlab-dev.aws-int.defra.cloud/open/rails-deployment/blob/master/config/deploy.rb#L69
+# so only creating cronjobs on that server, otherwise all jobs would be duplicated everyday!
+
+# This will run daily and update EA areas for addresses with x and y but without Area.
+every :day, at: (ENV["EA_AREA_LOOKUP"] || "1:05"), roles: [:db] do
+  rake ""
+end

--- a/lib/tasks/ea_lookups.rake
+++ b/lib/tasks/ea_lookups.rake
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+namespace :ea_lookups do
+  namespace :update do
+    desc "Populate EA Area information in all FloodRiskEngine::Location objects missing it."
+    task area: :environment do
+      run_for = FloodRiskBackOffice::Application.config.ea_area_lookup_run_for.to_i
+      run_until = run_for.minutes.from_now
+      locations_scope = FloodRiskEngine::Location.missing_ea_area.with_easting_and_northing
+
+      locations_scope.find_each do |location|
+        break if Time.now > run_until
+
+        FloodRiskEngine::UpdateWaterManagementAreaJob.perform_now(location)
+      end
+
+      Airbrake.close
+    end
+  end
+end

--- a/spec/lib/tasks/ea_lookups_spec.rb
+++ b/spec/lib/tasks/ea_lookups_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe "EA lookups task" do
+  describe "ea_lookups:update:area" do
+    include_context "rake"
+
+    let(:run_for) { 10 }
+
+    before do
+      expect(FloodRiskBackOffice::Application.config).to receive(:ea_area_lookup_run_for).and_return(run_for)
+    end
+
+    it "update area info into locations missing it" do
+      location_to_update = create(:location)
+      area = double(:area, code: "123", area_id: 123, area_name: "Foo", short_name: "Bar", long_name: "Baz")
+      result = double(:result, areas: [area], successful?: true)
+      water_management_area_count = FloodRiskEngine::WaterManagementArea.count + 1
+
+      expect(DefraRuby::Area::WaterManagementAreaService).to receive(:run).and_return(result)
+
+      subject.invoke
+
+      expect(FloodRiskEngine::WaterManagementArea.count).to eq(water_management_area_count)
+
+      new_water_management_area = FloodRiskEngine::WaterManagementArea.last
+
+      expect(location_to_update.reload.water_management_area).to eq(new_water_management_area)
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,10 +6,19 @@ require "spec_helper"
 require "rspec/rails"
 require "capybara/poltergeist"
 require "shoulda/matchers"
-require "support/factory_bot"
-require "support/shoulda"
-require "support/matchers/have_flash"
-require "support/matchers/have_form_error"
+
+# Requires supporting ruby files with custom matchers and macros, etc, in
+# spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
+# run as spec files by default. This means that files in spec/support that end
+# in _spec.rb will both be required and run as specs, causing the specs to be
+# run twice. It is recommended that you do not name files matching this glob to
+# end with _spec.rb. You can configure this pattern with the --pattern
+# option on the command line or in ~/.rspec, .rspec or `.rspec-local`.
+#
+# We make an exception for simplecov because that will already have been
+# required and run at the very top of spec_helper.rb
+support_files = Dir["./spec/support/**/*.rb"].reject { |file| file == "./spec/support/simplecov.rb" }
+support_files.each { |f| require f }
 
 Capybara.javascript_driver = :poltergeist
 

--- a/spec/support/shared_contexts/rake.rb
+++ b/spec/support/shared_contexts/rake.rb
@@ -1,0 +1,21 @@
+# Adapted from: https://thoughtbot.com/blog/test-rake-tasks-like-a-boss
+
+require "rake"
+
+RSpec.shared_context "rake" do
+  let(:rake)      { Rake::Application.new }
+  let(:task_name) { self.class.description }
+  let(:task_path) { "lib/tasks/#{task_name.split(":").first}" }
+  subject         { rake[task_name] }
+
+  def loaded_files_excluding_current_rake_file
+    $".reject {|file| file == Rails.root.join("#{task_path}.rake").to_s }
+  end
+
+  before do
+    Rake.application = rake
+    Rake.application.rake_require(task_path, [Rails.root.to_s], loaded_files_excluding_current_rake_file)
+
+    Rake::Task.define_task(:environment)
+  end
+end


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-604

Add a scheduled rake task that will run the Area lookup job for all locations that are missing the info.
The task contains a time constraint that will exit the job after it has run for X time. The X time is ENV configurable and default to 60 minutes.