### PR TITLE
Revert "Add scope on site addresses to Area Lookup"

### DIFF
--- a/lib/tasks/lookups.rake
+++ b/lib/tasks/lookups.rake
@@ -6,7 +6,7 @@ namespace :lookups do
     task missing_area: :environment do
       run_for = FloodRiskBackOffice::Application.config.area_lookup_run_for.to_i
       run_until = run_for.minutes.from_now
-      locations_scope = FloodRiskEngine::Location.from_site_address.missing_area.with_easting_and_northing
+      locations_scope = FloodRiskEngine::Location.missing_area.with_easting_and_northing
 
       locations_scope.find_each do |location|
         break if Time.now > run_until

--- a/spec/lib/tasks/lookups_spec.rb
+++ b/spec/lib/tasks/lookups_spec.rb
@@ -11,8 +11,7 @@ RSpec.describe "Lookups task" do
     end
 
     it "update area info into locations missing it" do
-      address = create(:address, :site)
-      location_to_update = create(:location, locatable: address)
+      location_to_update = create(:location)
       area = double(:area, code: "123", area_id: 123, area_name: "Foo", short_name: "Bar", long_name: "Baz")
       result = double(:result, areas: [area], successful?: true)
       water_management_area_count = FloodRiskEngine::WaterManagementArea.count + 1


### PR DESCRIPTION
Reverts DEFRA/flood-risk-back-office#155

https://eaflood.atlassian.net/browse/RUBY-604

We spotted an issue after adding the `from_site_address` scope to the query used in the automated job to update the Area on site locations that are missing one.

We added the scope to ensure we were only updating locations linked to site addresses, but when testing the job we spotted

- there is an existing bug in the service which means the address type is never set to anything other than `:primary`
- locations only get created for site addresses

To fix the area lookup just means reverting the introduction of the scope in the back office hence this change.