### PR TITLE
Fix default whenever log path

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -19,7 +19,7 @@
 
 # Learn more: http://github.com/javan/whenever
 
-log_output_path = ENV["EXPORT_SERVICE_CRON_LOG_OUTPUT_PATH"] || "/srv/ruby/flood-risk-back-office/shared/log/"
+log_output_path = ENV["EXPORT_SERVICE_CRON_LOG_OUTPUT_PATH"] || "/srv/ruby/flood-risk-activity-exemption-back-office/shared/log/"
 set :output, File.join(log_output_path, "whenever_cron.log")
 set :job_template, "/bin/bash -l -c 'eval \"$(rbenv init -)\" && :job'"
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-604

When trying to test the job in our AWS environments it didn't run. After some investigation spotted that its because the default log path does not actually match our environment.

For 'reasons' even though the project is called `flood-risk-back-office` the folder created in the environment is  `flood-risk-activity-exemption-back-office`. Hence the path did not exist so the cron job would fail when ran.

This fix should sort the problem.