### PR TITLE
Add format year_month_day_hyphens for time objects

### DIFF
--- a/config/locales/time_formats.yml
+++ b/config/locales/time_formats.yml
@@ -8,6 +8,7 @@ en:
     formats:
       long: "%d %B %Y %H:%M"
       medium: "%d %b %y %H:%M"
+      year_month_day_hyphens: "%Y-%m-%d"
   datetime:
     prompts:
       day: '- day -'


### PR DESCRIPTION
Since the formatting of dates is done authomatically by i18n, we want to make sure that the format is available for both Time and Date objects, so we don't need to add a custom rule in our code