### PR TITLE
Fix issue caused by API change

### DIFF
--- a/app/services/read_from_aws_s3.rb
+++ b/app/services/read_from_aws_s3.rb
@@ -14,7 +14,8 @@ class ReadFromAwsS3
 
     bucket.object(enrollment_export.file_name).presigned_url(
       :get,
-      expires_in: 20.minutes, secure: true,
+      expires_in: 20 * 60, # 20 minutes in seconds
+      secure: true,
       response_content_type: "text/csv",
       response_content_disposition: "attachment; filename=#{enrollment_export.file_name}"
     )


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-866

We have been tasked with generating an export of data from the service for the Electronic Public Register (EPR). This is exactly the same thing we have done for [Waste Exemptions](https://github.com/DEFRA/ruby-services-team/tree/master/services/wex) and [Waste Carriers](https://github.com/DEFRA/ruby-services-team/tree/master/services/wcr) and as such we brought in the code we used there, including our gem [defra-ruby-aws](https://github.com/DEFRA/defra-ruby-aws).

PR #189 handled that. But the project already has code for dealing with AWS and it seems something has gotten mixed up in the dependencies.

It seems we can still generate files and upload them to AWS. But when we try and retrieve them we get an error.

```bash
ArgumentError (expected :expires_in to be a number of seconds):
  app/services/read_from_aws_s3.rb:15:in `call'
  app/services/read_from_aws_s3.rb:8:in `run'
  app/services/read_enrollment_export_report.rb:17:in `call'
  app/services/read_enrollment_export_report.rb:10:in `run'
  app/controllers/admin/enrollment_exports_controller.rb:42:in `block (2 levels) in show'
  app/controllers/admin/enrollment_exports_controller.rb:35:in `show'
```

From what we can see the API has changed and we need to pass in seconds and not minutes now. This is possibly because the existing code is now using the dependency the defra-ruby-aws gem brought in. A review of what the defra-ruby-aws gem does confirms it uses seconds not minutes.

So this change makes that tweak, with the aim of getting the file download working again.