### PR TITLE
Update default port number in development.rb

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -41,7 +41,7 @@ Rails.application.configure do
 
   ## Default URL config
   host = ENV["DEFAULT_URL_HOST"] || "localhost"
-  port = ENV["SSL_PORT"].try!(:to_i) || ENV["PORT"].try!(:to_i) || 3000
+  port = ENV["SSL_PORT"].try!(:to_i) || ENV["PORT"].try!(:to_i) || 8000
   protocol = ENV["SSL_PORT"].present? ? "https" : "http"
 
   Rails.application.routes.default_url_options =


### PR DESCRIPTION
We have only recently identified this issue when working locally with the application. In the back office when an enrollment is selected there are a number of options which can change its status

- approve
- reject
- withdraw
- in progress

Even **Change status** where you can pick what status you want it to be!

Behind they scenes they are all a series of controllers that inherit `ChangeStatusBaseController`.

What we have found is that in our AWS environments everything is fine. When you select one of these e.g. **Withdraw**, and complete the action you are returned to the previously selected enrollment details page.

Locally though, this is not the case. It tries to redirect you to `http://localhost:3000/admin/enrollment_exemptions/3`.

Having looked into the issue we believe it originates from the old way the FRAE environment was structured. Both the front and back office applications expected to be running on separate instances. So there seems to have been a reliance on the env var `DEFAULT_URL_HOST` to set the `Rails.application.routes.default_url_options` in the environment files (`development.rb` and `production.rb`).

On top of that each defaulted to using port 3000. We now have both apps running on the same instance, which means they no longer can both use the same port number.

To get things working locally as it does in AWS requires 2 changes

1. This change to the default port number
2. A change to our Vagrant box configuration to set the env var `DEFAULT_URL_HOST` to `localhost:8000`.