### PR TITLE
Enable defra-ruby-email in the project

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,13 @@
 GIT
   remote: https://github.com/DEFRA/flood-risk-engine
-  revision: 29fdf86476437c330ed31552a97d4cc697a163f7
+  revision: 5732407449f9eb3d8ba53b525888ef1f5489626c
   branch: master
   specs:
     flood_risk_engine (1.0.2)
       activerecord-session_store (~> 1.0)
       defra_ruby_alert (~> 0.1.0)
       defra_ruby_area
+      defra_ruby_email
       dibber (~> 0.5)
       dotenv-rails (~> 2.1)
       ea-address_lookup (~> 0.3.0)
@@ -1006,6 +1007,8 @@ GEM
       rest-client (~> 2.0)
     defra_ruby_aws (0.2.0)
       aws-sdk-s3
+    defra_ruby_email (0.2.0)
+      rails (~> 4.2.11.1)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     devise (3.5.10)

--- a/config/initializers/defra_ruby_email.rb
+++ b/config/initializers/defra_ruby_email.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+DefraRubyEmail.configure do |configuration|
+  # Enable the routes mounted in this app if the environment is configured
+  # for it
+  configuration.enable = ENV["USE_LAST_EMAIL_CACHE"] || false
+end

--- a/config/initializers/flood_risk_engine.rb
+++ b/config/initializers/flood_risk_engine.rb
@@ -7,6 +7,9 @@ FloodRiskEngine.configure do |config|
   config.layout = "flood_risk_engine"
   config.require_journey_completed_in_same_browser = false
 
+  # Last email cache config
+  config.use_last_email_cache = ENV["USE_LAST_EMAIL_CACHE"] || false
+
   # Configure airbrake, which is done via the engine use defra_ruby_alert
   config.airbrake_enabled = ENV["USE_AIRBRAKE"]
   config.airbrake_host = Rails.application.secrets.airbrake_host

--- a/config/initializers/flood_risk_engine.rb
+++ b/config/initializers/flood_risk_engine.rb
@@ -8,6 +8,13 @@ FloodRiskEngine.configure do |config|
   config.require_journey_completed_in_same_browser = false
 
   # Last email cache config
+  # NOTE This will enable `/fre/email/last-email`. However we want to be
+  # consistent with the front office and our other services and access this at
+  # `/email/last-email`. The only way to do this was to mount the engine
+  # directly in the back-office. So we have this here more as a note to 'go
+  # look over there' for the actual implementation, and because it makes sense
+  # to have both routes working the same, even if we'll only really ever hit
+  # the `/email/last-email` version.
   config.use_last_email_cache = ENV["USE_LAST_EMAIL_CACHE"] || false
 
   # Configure airbrake, which is done via the engine use defra_ruby_alert

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,6 +73,8 @@ Rails.application.routes.draw do
     )
   end
 
+  mount DefraRubyEmail::Engine => "/email"
+
   # We use high voltage to manage static content including error-pages
   #get "/pages/*id" => 'high_voltage/pages#show', as: :page, format: false
 


### PR DESCRIPTION
Currently the [Waste Exemptions service](https://github.com/DEFRA/waste-exemptions-engine/pull/112) and the [Waste Carriers Frontend](https://github.com/DEFRA/waste-carriers-frontend/pull/227) have the ability to intercept and play back the details of the last email sent.

This feature is only enabled in our non-production environments and is used as part of our acceptance tests. However our QA @andrewhick has rightly pointed out that the functionality is inconsistent across our services.

Waste Exemptions has it throughout, Waste Carriers only has it in the old app, and Flood Risk Activity Exemptions doesn't have it at all. This makes writing and maintaining acceptance tests across the 3 services difficult and inconsistent so we have been asked to resolve the issue.

Rather than duplicate the existing code even more, we have created [defra-ruby-email](https://github.com/DEFRA/defra-ruby-email) a reusable engine that can be mounted into an application to provide the same functionality.

Having created the gem, we implemented it into the [flood-risk-engine](https://github.com/DEFRA/flood-risk-engine/pull/332) to add the feature to this service.

This change completes the implementation for the back-office.