### PR TITLE
Switch frae engine branch reference to master

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,7 @@ gem "whenever", "~> 0.9.4", require: false
 
 gem "flood_risk_engine",
     git: "https://github.com/DEFRA/flood-risk-engine",
-    branch: "master"
+    branch: "main"
 
 gem "defra_ruby_aws"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/DEFRA/flood-risk-engine
-  revision: 7a00188a4591076ba78adf8bf139d15f09da2b74
-  branch: master
+  revision: 5cd04ac1c2a679cb573a3299d64dc9109ab35be6
+  branch: main
   specs:
     flood_risk_engine (1.0.2)
       activerecord-session_store (~> 1.0)


### PR DESCRIPTION
We have updated the default branch in the engine to `main` as part of our work to phase out use of `master`.

This means we also need to update the reference in our Gemfile.