### PR TITLE
Update defra-ruby-aws to AWS:KMS version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1021,7 +1021,7 @@ GEM
     defra_ruby_area (2.0.0)
       nokogiri (~> 1.10.4)
       rest-client (~> 2.0)
-    defra_ruby_aws (0.2.0)
+    defra_ruby_aws (0.3.0)
       aws-sdk-s3
     defra_ruby_email (0.2.0)
       rails (~> 4.2.11.1)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1099

web-ops have asked us to set the encryption for everything uploaded going forward to `AWS:KMS`. This updates the project to a version of [defra-ruby-aws](https://github.com/DEFRA/defra-ruby-aws/pull/20) that uses it.