### PR TITLE
Update defra-ruby-aws to encryption configurable

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1025,7 +1025,7 @@ GEM
     defra_ruby_area (2.0.0)
       nokogiri (~> 1.10.4)
       rest-client (~> 2.0)
-    defra_ruby_aws (0.3.0)
+    defra_ruby_aws (0.3.1)
       aws-sdk-s3
     defra_ruby_email (0.2.0)
       rails (~> 4.2.11.1)

--- a/config/initializers/defra_ruby_aws.rb
+++ b/config/initializers/defra_ruby_aws.rb
@@ -7,7 +7,8 @@ DefraRuby::Aws.configure do |c|
     credentials: {
       access_key_id: ENV["AWS_DAILY_EXPORT_ACCESS_KEY_ID"],
       secret_access_key: ENV["AWS_DAILY_EXPORT_SECRET_ACCESS_KEY"]
-    }
+    },
+    encrypt_with_kms: ENV["AWS_ENCRYPT_WITH_KMS"]
   }
 
   c.buckets = [epr_bucket]


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1156

In PR #238 recently we updated [defra-ruby-aws](https://github.com/DEFRA/defra-ruby-aws) to a version that encrypted our uploads using AWS:KMS instead of AES256.

It turns out that our 3rd parties are unable to decrypt those files using this new encryption method. To allow them to is going to take some reconfiguration of our S3 buckets and that will impact a number of users. So we need to revert the change.

However rather than going back to the previous version of the gem we have updated it to make switching between encryption methods configurable. This updates the back-office to use the updated gem and prepare it for being able to switch using config in the future.