### PR TITLE
Upload EPR exports to EPR folder

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ gem "flood_risk_engine",
     git: "https://github.com/DEFRA/flood-risk-engine",
     branch: "main"
 
-gem "defra_ruby_aws"
+gem "defra_ruby_aws", "~> 0.4"
 
 # Allows us to automatically generate the change log from the tags, issues,
 # labels and pull requests on GitHub. Added as a dependency so all dev's have

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,7 +80,7 @@ GEM
       execjs
     awesome_print (1.8.0)
     aws-eventstream (1.1.0)
-    aws-partitions (1.378.0)
+    aws-partitions (1.403.0)
     aws-sdk-accessanalyzer (1.12.0)
       aws-sdk-core (~> 3, >= 3.109.0)
       aws-sigv4 (~> 1.1)
@@ -249,7 +249,7 @@ GEM
     aws-sdk-connectparticipant (1.8.0)
       aws-sdk-core (~> 3, >= 3.109.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-core (3.109.0)
+    aws-sdk-core (3.110.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
       aws-sigv4 (~> 1.1)
@@ -881,7 +881,7 @@ GEM
     aws-sdk-route53resolver (1.21.0)
       aws-sdk-core (~> 3, >= 3.109.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.82.0)
+    aws-sdk-s3 (1.86.0)
       aws-sdk-core (~> 3, >= 3.109.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.1)
@@ -1057,7 +1057,7 @@ GEM
     defra_ruby_area (2.0.0)
       nokogiri (~> 1.10.4)
       rest-client (~> 2.0)
-    defra_ruby_aws (0.3.1)
+    defra_ruby_aws (0.4.1)
       aws-sdk-s3
     defra_ruby_email (0.2.0)
       rails (~> 4.2.11.1)
@@ -1369,7 +1369,7 @@ DEPENDENCIES
   byebug
   capybara (~> 2.6.2)
   database_cleaner (~> 1.5.1)
-  defra_ruby_aws
+  defra_ruby_aws (~> 0.4)
   devise (~> 3.5.10)
   devise_invitable (~> 1.6.0)
   devise_security_extension (~> 0.10.0)

--- a/app/services/concerns/can_load_file_to_aws.rb
+++ b/app/services/concerns/can_load_file_to_aws.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 module CanLoadFileToAws
-  def load_file_to_aws_bucket
+  def load_file_to_aws_bucket(options = {})
     result = nil
 
     3.times do
-      result = bucket.load(File.new(file_path, "r"))
+      result = bucket.load(File.new(file_path, "r"), options)
 
       break if result.successful?
     end

--- a/app/services/reports/epr_export_service.rb
+++ b/app/services/reports/epr_export_service.rb
@@ -9,7 +9,9 @@ module Reports
     def run
       populate_temp_file
 
-      load_file_to_aws_bucket
+      options = { s3_directory: "EPR" }
+
+      load_file_to_aws_bucket(options)
     rescue StandardError => e
       Airbrake.notify e, file_name: file_name
       Rails.logger.error "Generate EPR export csv error for #{file_name}:\n#{e}"

--- a/spec/services/reports/epr_export_service_spec.rb
+++ b/spec/services/reports/epr_export_service_spec.rb
@@ -21,7 +21,7 @@ module Reports
         expect(DefraRuby::Aws).to receive(:get_bucket).and_return(bucket)
         expect(File).to receive(:new).and_return(file)
         expect(File).to receive(:exist?).and_return(true)
-        expect(bucket).to receive(:load).with(file).and_return(result)
+        expect(bucket).to receive(:load).with(file, { s3_directory: "EPR" }).and_return(result)
 
         expect(File).to receive(:unlink)
 
@@ -46,7 +46,7 @@ module Reports
         expect(DefraRuby::Aws).to receive(:get_bucket).and_return(bucket)
         expect(File).to receive(:new).and_return(file).exactly(3).times
         expect(File).to receive(:exist?).and_return(true)
-        expect(bucket).to receive(:load).with(file).and_return(result).exactly(3).times
+        expect(bucket).to receive(:load).with(file, { s3_directory: "EPR" }).and_return(result).exactly(3).times
 
         expect(result).to receive(:error)
         expect(Airbrake).to receive(:notify)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1240

We used to upload to the root but now we have to upload to an EPR subfolder.

All other exports should still go to the root.

Implementation of this involved updating defra-ruby-aws.