### PR TITLE
Add hidden labels to the Search and Select menus

### DIFF
--- a/app/views/admin/enrollment_exemptions/index.html.erb
+++ b/app/views/admin/enrollment_exemptions/index.html.erb
@@ -22,7 +22,7 @@
             <div class="govuk-grid-row">
               <div class="govuk-grid-column-one-half">
                 <%= f.govuk_text_field :q,
-                    label: { text: "" },
+                    label: { text: t(".search_label"), style: "display:none" },
                     width: 20,
                     id: "search",
                     placeholder: t(:search) %>
@@ -35,7 +35,7 @@
                     options: { include_blank: true },
                     width: 20,
                     inline: true,
-                    label: { text: "" } %>
+                    label: { text: t(".select_label"), style: "display:none" } %>
               </div>
               <div class="govuk-grid-column-one-quarter">
                 <%= f.govuk_submit t(".search_button") %>

--- a/config/locales/admin/enrollment_exemptions/index/enrollment_exemptions.en.yml
+++ b/config/locales/admin/enrollment_exemptions/index/enrollment_exemptions.en.yml
@@ -24,6 +24,7 @@ en:
           - grid reference
           - exemption code, e.g. FRA1
         search_label: Search for a registration
+        select_label: Select a status
         search_button: Search
         submitted_label: Submitted
         not_submitted_label: Not yet submitted


### PR DESCRIPTION
This addresses QA feedback that the Search and Select menus didn't have label text. 

https://eaflood.atlassian.net/browse/RUBY-1477