### PR TITLE
Styling: View users - Enhancements

### DIFF
--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -2,20 +2,18 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">
-    <h1 class="govuk-heading-l"><%= User.model_name.human(count: 2) %></h1>
-  </div>
-  <div class="govuk-grid-column-one-quarter">
-    <%= link_to t('devise.invite_user'), new_user_invitation_path, class: 'govuk-button' %>
+    <h1 class="govuk-heading-l"><%= @page_title %></h1>
+    <p class="govuk-body"><%= link_to t('devise.invite_user'), new_user_invitation_path %></p>
   </div>
 </div>
 
 
-<table class="govuk-table" aria-label="<%= t('.title') %>">
+<table class="govuk-table" aria-label="<%= @page_title %>">
   <thead class="govuk-table__head">
-    <% %i[email roles invitation_accepted? enabled? actions].each do |att| %>
+    <% %i[email roles invitation_accepted status].each do |att| %>
       <th class="govuk-table__header" scope="col"><%= User.human_attribute_name att %></th>
     <% end %>
-    <th class="govuk-table__header" scope="col">&nbsp;</th>
+    <th class="govuk-table__header" scope="col" colspan="2"><%= User.human_attribute_name "actions" %></th>
   </thead>
   <tbody class="govuk-table__body">
     <%= render collection: @users, partial: 'admin/users/user' %>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -26,12 +26,7 @@
             admin_users_path,
             class: "govuk-header__link" %>
       </li>
-      <li class="govuk-header__navigation-item">
-        <%= link_to t('devise.invite_user'),
-            new_user_invitation_path,
-            class: "govuk-header__link" %>
     <% end %>
-
 
     <li class="govuk-header__navigation-item">
       <%= link_to t('devise.sign_out'),

--- a/config/locales/users.en.yml
+++ b/config/locales/users.en.yml
@@ -1,8 +1,9 @@
 en:
   admin:
     users:
+
       user:
-        not_invited: "-"
+        not_invited: Invitation accepted
         disable: Disable
         disabled: Disabled
         enable: Enable
@@ -12,4 +13,4 @@ en:
       edit_disable:
         title: Disable user
       index:
-        title: Users
+        title: Admin users

--- a/spec/features/nav_menu_feature_spec.rb
+++ b/spec/features/nav_menu_feature_spec.rb
@@ -42,7 +42,6 @@ RSpec.feature "Admin menu" do
         expect(page).to have_link("New")
         expect(page).to have_link("Export")
         expect(page).to have_link("Users")
-        expect(page).to have_link("Invite user")
 
         click_link t("devise.sign_out")
       end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1502

- Take the question mark off ‘Invitation accepted' column and rename the enabled column to 'Status'
- Add accepted into the ‘Invitation accepted’ column, rather than the dash.
- Make green invite button be a link under the H1
- H1 needs to say ‘Admin users’
- Invite users link removed from header menu
- Ensure there are no empty table headers (actions column)