### PR TITLE
Validate the postcode length

### DIFF
--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -4,7 +4,8 @@ class Address < ActiveRecord::Base
   validates :premises, presence: true
   validates :street_address, presence: true
   validates :city, presence: true
-  validates :postcode, "flood_risk_engine/postcode": { presence: true }
+  validates :postcode, presence: true
+  validates :postcode, length: { maximum: 8 }
 
   def to_param
     token

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -52,6 +52,7 @@ en:
               blank: Enter a town or city
             postcode:
               blank: Enter a postcode
+              too_long: Postcode is too long (maximum 8 characters)
         correspondence_contact:
           attributes:
             full_name:
@@ -76,6 +77,7 @@ en:
               blank: Enter a town or city
             postcode:
               blank: Enter a postcode
+              too_long: Postcode is too long (maximum 8 characters)
     allowed_roles:
       system: System user
       super_agent: Administrative super user

--- a/spec/features/edit_address_spec.rb
+++ b/spec/features/edit_address_spec.rb
@@ -26,9 +26,9 @@ RSpec.describe "Edit address", type: :feature do
   end
 
   scenario "unsuccessfully" do
-    fill_in "Postcode", with: "foo-bar"
+    fill_in "Postcode", with: "foo-bar-foo"
     click_on "Continue"
 
-    expect(page).to have_css(".govuk-error-message", text: "Enter a valid UK postcode")
+    expect(page).to have_css(".govuk-error-message", text: "Postcode is too long")
   end
 end

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -6,5 +6,6 @@ RSpec.describe Address do
     it { should validate_presence_of(:street_address) }
     it { should validate_presence_of(:city) }
     it { should validate_presence_of(:postcode) }
+    it { should validate_length_of(:postcode).is_at_most(8) }
   end
 end


### PR DESCRIPTION
Relates to:
https://eaflood.atlassian.net/browse/RUBY-1495?focusedCommentId=332672

There is a database constraint on the postcode column - max 8 chars length
Previously we used the postcode validator to check the format of the postcode.
This opened a can of worms because it also does a postcode look up.
As this form is to be used by NCCC to fix incorrect addresses, we are
going with a manual version.