### PR TITLE
Update engine without legacy code

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,11 @@ gem "govuk_design_system_formbuilder"
 
 gem "dotenv-rails"
 
+# This has been removed from the engine so re-adding here temporarily
+# until we refactor it out of all the admin forms
+gem "reform", "~> 2.6"
+gem "reform-rails", "~> 0.2.2"
+
 group :development do
   gem "awesome_print"
   gem "rubocop"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DEFRA/flood-risk-engine
-  revision: fa9f18947689da8bd1faeab3fa702fa3c8c0b712
+  revision: df0f4a07b82f30975786b9b1af46cfe8d932416c
   branch: rails6
   specs:
     flood_risk_engine (1.1)
@@ -13,7 +13,6 @@ GIT
       defra_ruby_validators
       dibber (~> 0.5)
       dotenv-rails (~> 2.1)
-      finite_machine (~> 0.11.3)
       has_secure_token (~> 1.0.0)
       high_voltage (~> 3.0)
       jquery-rails (~> 4.4)
@@ -21,13 +20,9 @@ GIT
       os_map_ref (= 0.4.2)
       phonelib (~> 0.6)
       rails (~> 6.0)
-      reform (= 2.6)
-      reform-rails (= 0.2.2)
       sucker_punch (~> 2.0.2)
-      sync
       uk_postcode (~> 2.1)
       validates_email_format_of (~> 1.6)
-      virtus (~> 1.0)
 
 GEM
   remote: https://rubygems.org/
@@ -1209,10 +1204,6 @@ GEM
     aws-sigv2 (1.0.2)
     aws-sigv4 (1.2.3)
       aws-eventstream (~> 1, >= 1.0.2)
-    axiom-types (0.1.1)
-      descendants_tracker (~> 0.0.4)
-      ice_nine (~> 0.11.0)
-      thread_safe (~> 0.3, >= 0.3.1)
     bcrypt (3.1.16)
     builder (3.2.4)
     bullet (6.1.4)
@@ -1229,8 +1220,6 @@ GEM
       xpath (~> 3.2)
     chronic (0.10.2)
     cliver (0.3.2)
-    coercible (1.0.0)
-      descendants_tracker (~> 0.0.1)
     concurrent-ruby (1.0.5)
     console (1.12.0)
       fiber-local
@@ -1265,8 +1254,6 @@ GEM
       phonelib
       rest-client (~> 2.0)
       validates_email_format_of
-    descendants_tracker (0.0.4)
-      thread_safe (~> 0.3, >= 0.3.1)
     devise (4.8.0)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -1296,7 +1283,6 @@ GEM
       htmlentities (~> 4.3.3)
       launchy (~> 2.1)
       mail (~> 2.7)
-    equalizer (0.0.11)
     erubi (1.10.0)
     execjs (2.7.0)
     factory_bot (6.2.0)
@@ -1319,7 +1305,6 @@ GEM
     faraday-net_http_persistent (1.1.0)
     ffi (1.15.0)
     fiber-local (1.0.0)
-    finite_machine (0.11.3)
     fuubar (2.5.1)
       rspec-core (~> 3.0)
       ruby-progressbar (~> 1.4)
@@ -1349,7 +1334,6 @@ GEM
       domain_name (~> 0.5)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
-    ice_nine (0.11.2)
     jmespath (1.4.0)
     jquery-rails (4.4.0)
       rails-dom-testing (>= 1, < 3)
@@ -1466,7 +1450,7 @@ GEM
       disposable (~> 0.5.0)
       representable (>= 3.1.1, < 3.2.0)
       uber (< 0.2.0)
-    reform-rails (0.2.2)
+    reform-rails (0.2.3)
       activemodel (>= 5.0)
       reform (>= 2.3.1, < 3.0.0)
     regexp_parser (2.1.1)
@@ -1555,7 +1539,6 @@ GEM
       sprockets (>= 3.0.0)
     sucker_punch (2.0.4)
       concurrent-ruby (~> 1.0.0)
-    sync (0.5.0)
     thor (1.1.0)
     thread_safe (0.3.6)
     tilt (2.0.10)
@@ -1570,18 +1553,13 @@ GEM
     uk_postcode (2.1.6)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.7)
+    unf_ext (0.0.8)
     unicode-display_width (2.0.0)
     uniform_notifier (1.14.2)
     validates_email_format_of (1.6.3)
       i18n
     validates_timeliness (5.0.0)
       timeliness (>= 0.3.10, < 1)
-    virtus (1.0.5)
-      axiom-types (~> 0.1)
-      coercible (~> 1.0)
-      descendants_tracker (~> 0.0, >= 0.0.3)
-      equalizer (~> 0.0, >= 0.0.9)
     warden (1.2.9)
       rack (>= 2.0.9)
     websocket-driver (0.7.5)
@@ -1628,6 +1606,8 @@ DEPENDENCIES
   rails (~> 6.0.3)
   rails-controller-testing
   record_tag_helper
+  reform (~> 2.6)
+  reform-rails (~> 0.2.2)
   rolify
   rspec-activemodel-mocks
   rspec-rails

--- a/app/controllers/admin/enrollments_controller.rb
+++ b/app/controllers/admin/enrollments_controller.rb
@@ -4,10 +4,7 @@ module Admin
     def new
       authorize FloodRiskEngine::Enrollment
 
-      # This is used later  to ID the enrollment exemption as AD
-      bo_enrollment = FloodRiskEngine::Enrollment.create(updated_by_user_id: current_user.id)
-
-      redirect_to flood_risk_engine.enrollment_step_path(bo_enrollment, bo_enrollment.initial_step)
+      redirect_to flood_risk_engine.new_start_form_path
     end
   end
 end

--- a/app/forms/admin/enrollment_exemptions/base_change_state_form.rb
+++ b/app/forms/admin/enrollment_exemptions/base_change_state_form.rb
@@ -1,4 +1,5 @@
 require_dependency "reform"
+
 module Admin
   module EnrollmentExemptions
     class BaseChangeStateForm < Reform::Form

--- a/config/initializers/flood_risk_engine.rb
+++ b/config/initializers/flood_risk_engine.rb
@@ -5,7 +5,6 @@ FloodRiskEngine.configure do |config|
   # because that layout may include calls to helper methods that we (as an isolated engine)
   # don't have access to.
   config.layout = "flood_risk_engine"
-  config.require_journey_completed_in_same_browser = false
 
   # Last email cache config
   # NOTE This will enable `/fre/email/last-email`. However we want to be

--- a/config/initializers/paper_trail.rb
+++ b/config/initializers/paper_trail.rb
@@ -13,5 +13,3 @@ end
 
 User.has_paper_trail
 Role.has_paper_trail
-
-FloodRiskEngine::Enrollments::StepsController.before_action :set_paper_trail_whodunnit

--- a/config/initializers/pundit.rb
+++ b/config/initializers/pundit.rb
@@ -1,1 +1,1 @@
-FloodRiskEngine::Enrollments::StepsController.include Pundit
+FloodRiskEngine::FormsController.include Pundit

--- a/config/initializers/reform.rb
+++ b/config/initializers/reform.rb
@@ -1,0 +1,7 @@
+require_dependency "reform"
+
+require "reform/form/active_model/validations"
+
+Reform::Form.class_eval do
+  include Reform::Form::ActiveModel::Validations
+end

--- a/spec/controllers/admin/enrollments_controller_spec.rb
+++ b/spec/controllers/admin/enrollments_controller_spec.rb
@@ -19,9 +19,9 @@ module Admin
         get :new
       end
 
-      it "should redirect to engine's initial step path" do
+      it "should redirect to engine's initial start path" do
         expect(response).to be_redirect
-        expect(response.location).to match("steps/add_exemptions")
+        expect(response.location).to match("start")
       end
     end
   end

--- a/spec/factories/enrollments_factory.rb
+++ b/spec/factories/enrollments_factory.rb
@@ -18,12 +18,13 @@ FactoryBot.define do
   # Exemption and random valid_from selected for EnrollmentExemption
 
   factory :confirmed_random_pending, parent: :base_back_office_enrollment do
+    reference_number { FloodRiskEngine::ReferenceNumber.create }
+    submitted_at { Time.current }
+
     after(:create) do |object|
       create(:exemption) if FloodRiskEngine::Exemption.count == 0
 
       exemption = FloodRiskEngine::Exemption.offset(rand(FloodRiskEngine::Exemption.count)).first
-
-      object.submit
 
       object.enrollment_exemptions.create(
         exemption: exemption,

--- a/spec/factories/flood_risk_engine_contacts_factory.rb
+++ b/spec/factories/flood_risk_engine_contacts_factory.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :flood_risk_engine_contact, class: "FloodRiskEngine::Contact" do
+    title             { 1 }
+    full_name         { "#{Faker::Name.first_name} #{Faker::Name.last_name}" }
+    position          { Faker::Company.profession }
+    email_address     { Faker::Internet.email }
+    suffix            { Faker::Name.suffix }
+    date_of_birth     { 30.years.ago }
+    telephone_number  { Faker::PhoneNumber.phone_number }
+  end
+end

--- a/spec/factories/submitted_enrollments_factory.rb
+++ b/spec/factories/submitted_enrollments_factory.rb
@@ -13,10 +13,6 @@ FactoryBot.define do
       submitted_at { Time.current }
 
       after(:create) do |object|
-        object.enrollment_exemptions.each do |ee|
-          ee.status = 1
-        end
-
         object.organisation = if ot.to_sym == :partnership
                                 create(:organisation, :"as_#{ot}", :with_partners, name: Faker::Company.name)
                               else

--- a/spec/factories/submitted_enrollments_factory.rb
+++ b/spec/factories/submitted_enrollments_factory.rb
@@ -9,7 +9,14 @@ FactoryBot.define do
     next if ot.to_sym == :unknown
 
     factory :"submitted_#{ot}", parent: :confirmed_random_pending do
+      reference_number { FloodRiskEngine::ReferenceNumber.create }
+      submitted_at { Time.current }
+
       after(:create) do |object|
+        object.enrollment_exemptions.each do |ee|
+          ee.status = 1
+        end
+
         object.organisation = if ot.to_sym == :partnership
                                 create(:organisation, :"as_#{ot}", :with_partners, name: Faker::Company.name)
                               else
@@ -19,8 +26,6 @@ FactoryBot.define do
         object.organisation.primary_address = build :simple_address
 
         object.secondary_contact = build :contact
-
-        object.submit
 
         object.save!
       end

--- a/spec/features/new_registration_spec.rb
+++ b/spec/features/new_registration_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "New scenario" do
 
     within("#navigation") { click_link("New") }
 
-    expect(page).to have_css("h1", text: "Select the exemption you want to register")
+    expect(page).to have_css("h3", text: "Before you register you must")
 
     # check that the navigation links are no longer visible
     expect(page).not_to have_css("#navigation")

--- a/spec/models/enrollment_export_spec.rb
+++ b/spec/models/enrollment_export_spec.rb
@@ -24,8 +24,6 @@ RSpec.describe EnrollmentExport do
     let(:export) { create(:enrollment_export, :with_dates, :with_file_name) }
 
     before(:each) do
-      FactoryBot.create_list(:page_declaration, 5) # not submitted - should never appear
-
       FactoryBot.create_list(:submitted_individual, 3)
       FactoryBot.create_list(:submitted_partnership, 3)
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1592

There are some components (notably Reform) that have been removed from the engine but are still being refactored out of the back office. So I've added some things back in temporarily.

Also noticed that we'll need to change the way we store the AD status in the engine - this will be done in an upcoming PR.