### PR TITLE
Improve UX for list of back office users

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -5,9 +5,16 @@ module Admin
     def index
       authorize User
 
-      @users = policy_scope(User)
-               .order(:email)
-               .page(params[:page])
+      @users = User.where(disabled_at: nil).order(:email).page(params[:page])
+    end
+
+    def all
+      authorize User
+
+      @users = User.all.order(:email).page(params[:page])
+
+      @show_all_users = true
+      render :index
     end
 
     def edit

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -3,6 +3,10 @@ class UserPolicy < ApplicationPolicy
     system_user?
   end
 
+  def all?
+    system_user?
+  end
+
   def update?
     system_user?
   end

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -4,9 +4,15 @@
   <div class="govuk-grid-column-three-quarters">
     <h1 class="govuk-heading-l"><%= @page_title %></h1>
     <p class="govuk-body"><%= link_to t('devise.invite_user'), new_user_invitation_path %></p>
+    <p class="govuk-body">
+      <% if @show_all_users %>
+        <%= link_to t(".show_enabled_users_only"), admin_users_path %>
+      <% else %>
+        <%= link_to t(".show_all_users"), all_admin_users_path %>
+      <% end %>
+    </p>
   </div>
 </div>
-
 
 <table class="govuk-table" aria-label="<%= @page_title %>">
   <thead class="govuk-table__head">

--- a/config/locales/users.en.yml
+++ b/config/locales/users.en.yml
@@ -18,3 +18,5 @@ en:
         submit: Disable user
       index:
         title: Admin users
+        show_all_users: Show all users
+        show_enabled_users_only: Show enabled users only

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,9 @@ Rails.application.routes.draw do
 
   namespace :admin do
     resources :users, only: [:index, :show, :edit, :update] do
+      collection do
+        get :all
+      end
       get :edit_disable
       patch :disable
       patch :enable

--- a/spec/features/admin/list_users_feature_spec.rb
+++ b/spec/features/admin/list_users_feature_spec.rb
@@ -4,15 +4,21 @@ RSpec.feature "As an System user, I want to view a list of users" do
   end
 
   context "authorised" do
-    scenario "System user can view user list" do
-      create_list :user, 10
-      user = User.first
+    scenario "System user can view list of 'enable' users and toggle to view 'all' " do
+      create_list :user, 2
+      create_list :disabled_user, 2
 
+      user = User.first
       user.grant :system
       login_as user
       visit admin_users_path
+      expect(page).to have_css("tbody tr", count: 2)
 
-      expect(page).to have_css("tbody tr", count: 10)
+      click_link "Show all users"
+      expect(page).to have_css("tbody tr", count: 4)
+
+      click_link "Show enabled users only"
+      expect(page).to have_css("tbody tr", count: 2)
     end
   end
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1596

Here we introduce a toggle to view Enabled / All users

Have removed the 'policy_scope' as it does some strange caching
(that I don't really understand)