### PR TITLE
Add config to validate with Companies House

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DEFRA/flood-risk-engine
-  revision: 03728745f045c810886f78a84a176f0b08fffea8
+  revision: 9835effcde1b49ec701340fffe03e670ce35f9bd
   branch: rails6
   specs:
     flood_risk_engine (1.1)
@@ -15,7 +15,6 @@ GIT
       dotenv-rails (~> 2.1)
       has_secure_token (~> 1.0.0)
       high_voltage (~> 3.0)
-      jquery-rails (~> 4.4)
       nokogiri (>= 1.11)
       os_map_ref (= 0.4.2)
       phonelib (~> 0.6)
@@ -92,9 +91,9 @@ GEM
       zeitwerk (~> 2.2, >= 2.2.2)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
-    airbrake (11.0.3)
-      airbrake-ruby (~> 5.1)
-    airbrake-ruby (5.2.1)
+    airbrake (12.0.0)
+      airbrake-ruby (~> 6.0)
+    airbrake-ruby (6.0.0)
       rbtree3 (~> 0.5)
     ast (2.4.2)
     async (1.29.0)
@@ -1352,7 +1351,7 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
-    marcel (1.0.1)
+    marcel (1.0.2)
     method_source (1.0.0)
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)

--- a/config/initializers/flood_risk_engine.rb
+++ b/config/initializers/flood_risk_engine.rb
@@ -46,5 +46,7 @@ FloodRiskEngine.configure do |config|
     :session_id,
     :authenticity_token
   ]
+
+  config.companies_house_api_key = ENV["COMPANIES_HOUSE_API_KEY"]
 end
 FloodRiskEngine.start_airbrake


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1506

Previously we just validated the format of the Companies House number to see if it looked about right. Now we
use our validation gem to send it off to the Companies House API to check if it actually belongs to an active company.

---

Depends on https://github.com/DEFRA/flood-risk-engine/pull/435 – CI will fail until this engine update is merged in