### PR TITLE
Prepend user email to comments

### DIFF
--- a/app/controllers/admin/enrollment_exemptions/approve_controller.rb
+++ b/app/controllers/admin/enrollment_exemptions/approve_controller.rb
@@ -29,6 +29,7 @@ module Admin
         {
           status: :approved,
           comment_event: "Approved exemption",
+          comment_user_id: current_user.id,
           accept_reject_decision_user_id: current_user.id,
           accept_reject_decision_at: Time.zone.now
         }

--- a/app/controllers/admin/enrollment_exemptions/change_status_controller.rb
+++ b/app/controllers/admin/enrollment_exemptions/change_status_controller.rb
@@ -8,7 +8,11 @@ module Admin
       end
 
       def create
-        update_params = enrollment_exemption_params.merge(comment_event: comment_event)
+        update_params =
+          enrollment_exemption_params.merge(
+            comment_event: comment_event,
+            comment_user_id: current_user.id
+          )
 
         if @enrollment_exemption.action!(update_params)
           redirect_to admin_enrollment_exemption_path(@enrollment_exemption)

--- a/app/controllers/admin/enrollment_exemptions/deregister_controller.rb
+++ b/app/controllers/admin/enrollment_exemptions/deregister_controller.rb
@@ -28,7 +28,8 @@ module Admin
         enrollment_exemption_params.merge(
           {
             status: :deregistered,
-            comment_event: comment_event
+            comment_event: comment_event,
+            comment_user_id: current_user.id
           }
         )
       end

--- a/app/controllers/admin/enrollment_exemptions/in_progress_controller.rb
+++ b/app/controllers/admin/enrollment_exemptions/in_progress_controller.rb
@@ -22,7 +22,8 @@ module Admin
         {
           status: :being_processed,
           comment_content: "n/a",
-          comment_event: "Status changed to In Progress"
+          comment_event: "Status changed to In progress",
+          comment_user_id: current_user.id
         }
       end
 

--- a/app/controllers/admin/enrollment_exemptions/reject_controller.rb
+++ b/app/controllers/admin/enrollment_exemptions/reject_controller.rb
@@ -29,6 +29,7 @@ module Admin
         {
           status: :rejected,
           comment_event: "Rejected exemption",
+          comment_user_id: current_user.id,
           accept_reject_decision_user_id: current_user.id,
           accept_reject_decision_at: Time.zone.now
         }

--- a/app/controllers/admin/enrollment_exemptions/resend_approval_email_controller.rb
+++ b/app/controllers/admin/enrollment_exemptions/resend_approval_email_controller.rb
@@ -22,7 +22,10 @@ module Admin
       def enrollment_exemption_params
         params.require(:enrollment_exemption).permit(
           :comment_content
-        ).merge(comment_event: "Reissued registration approved email")
+        ).merge(
+          comment_event: "Reissued registration approved email",
+          comment_user_id: current_user.id
+        )
       end
 
       def load_and_authorise_enrollment_exemption

--- a/app/controllers/admin/enrollment_exemptions/withdraw_controller.rb
+++ b/app/controllers/admin/enrollment_exemptions/withdraw_controller.rb
@@ -27,7 +27,8 @@ module Admin
       def withdrawal_params
         {
           status: :withdrawn,
-          comment_event: "Withdrawn exemption"
+          comment_event: "Withdrawn exemption",
+          comment_user_id: current_user.id
         }
       end
 

--- a/app/models/enrollment_exemption.rb
+++ b/app/models/enrollment_exemption.rb
@@ -3,7 +3,7 @@
 # to add comments. Here we add an `#action!` method, to enable
 # validation and creation of new comments
 class EnrollmentExemption < FloodRiskEngine::EnrollmentExemption
-  attr_accessor :commentable, :comment_content, :comment_event
+  attr_accessor :commentable, :comment_content, :comment_event, :comment_user_id
 
   validates :comment_content, presence: true, if: :commentable?
   before_save :create_comment, if: :commentable?
@@ -28,6 +28,6 @@ class EnrollmentExemption < FloodRiskEngine::EnrollmentExemption
   end
 
   def create_comment
-    comments.create(content: comment_content, event: comment_event)
+    comments.create(user_id: comment_user_id, content: comment_content, event: comment_event)
   end
 end

--- a/app/views/admin/enrollment_exemptions/show/_comment_history.html.erb
+++ b/app/views/admin/enrollment_exemptions/show/_comment_history.html.erb
@@ -10,7 +10,10 @@
       <% expanded = comment == comments.first %>
       <tr class="govuk-table__row">
         <th scope="row" class="govuk-table__header govuk-body-s govuk-!-width-one-third"><%= comment.event %></th>
-        <td class="govuk-table__cell govuk-body-s"><%= comment.content %></td>
+        <td class="govuk-table__cell govuk-body-s">
+          <%= "#{comment.user.email} - " if comment.user %>
+          <%= comment.content %>
+        </td>
         <td class="govuk-table__cell govuk-body-s">
           <%= comment.created_at.to_s(:long) %>
           <br/>

--- a/spec/features/approve_spec.rb
+++ b/spec/features/approve_spec.rb
@@ -21,7 +21,10 @@ RSpec.describe "Approve an enrollment", type: :feature do
     click_on "Confirm and send email"
 
     within("#status") { expect(page).to have_text("Approved") }
-    within("#comment-history") { expect(page).to have_text("Approved by Alice!") }
+
+    within("#comment-history") do
+      expect(page).to have_text("#{user.email} - Approved by Alice!")
+    end
 
     ee = enrollment_exemption.reload
     expect(ee.accept_reject_decision_user_id).to be_present

--- a/spec/features/change_status_spec.rb
+++ b/spec/features/change_status_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "Change status", type: :feature do
 
     within("#status") { expect(page).to have_text("Withdrawn") }
     within("#comment-history") do
-      expect(page).to have_text("Changed by Alice!")
+      expect(page).to have_text("#{user.email} - Changed by Alice!")
       expect(page).to have_text("Changed exemption from #{enrollment_exemption.status} to withdrawn")
     end
   end

--- a/spec/features/deregister_spec.rb
+++ b/spec/features/deregister_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Deregister an enrollment", type: :feature do
 
     within("#comment-history") do
       expect(page).to have_text("Deregistered exemption with Operator failings")
-      expect(page).to have_text("Deregistered by Alice!")
+      expect(page).to have_text("#{user.email} - Deregistered by Alice!")
     end
   end
 

--- a/spec/features/in_progress_spec.rb
+++ b/spec/features/in_progress_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe "In progress", type: :feature do
     click_on "Confirm In Progress status"
 
     within("#status") { expect(page).to have_text("In progress") }
-    within("#comment-history") { expect(page).to have_text("Status changed to In Progress") }
+    within("#comment-history") { expect(page).to have_text("Status changed to In progress") }
+    within("#comment-history") { expect(page).to have_text("#{user.email} - n/a") }
   end
 end

--- a/spec/features/reject_spec.rb
+++ b/spec/features/reject_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "Reject an enrollment", type: :feature do
     click_on "Confirm and send email"
 
     within("#status") { expect(page).to have_text("Rejected") }
-    within("#comment-history") { expect(page).to have_text("Rejected by Alice!") }
+    within("#comment-history") { expect(page).to have_text("#{user.email} - Rejected by Alice!") }
 
     ee = enrollment_exemption.reload
     expect(ee.accept_reject_decision_user_id).to be_present

--- a/spec/features/resend_approval_email_spec.rb
+++ b/spec/features/resend_approval_email_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "Resend an approval email", type: :feature do
     click_on "Confirm and send email"
 
     within("#comment-history") do
-      expect(page).to have_text("Reissued by Alice!")
+      expect(page).to have_text("#{user.email} - Reissued by Alice!")
       expect(page).to have_text("Reissued registration approved email")
     end
   end

--- a/spec/features/withdraw_spec.rb
+++ b/spec/features/withdraw_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Withdraw an enrollment", type: :feature do
     click_on "Withdraw"
 
     within("#status") { expect(page).to have_text("Withdrawn") }
-    within("#comment-history") { expect(page).to have_text("Withdrawn by Alice!") }
+    within("#comment-history") { expect(page).to have_text("#{user.email} - Withdrawn by Alice!") }
   end
 
   scenario "unsuccessfully" do

--- a/spec/models/enrollment_exemption_spec.rb
+++ b/spec/models/enrollment_exemption_spec.rb
@@ -30,8 +30,16 @@ RSpec.describe EnrollmentExemption do
       end
 
       context "and a comment" do
+        let(:user) { create(:user) }
+
         before do
-          params.merge!({ comment_content: "Hola!", comment_event: "Approved" })
+          params.merge!(
+            {
+              comment_content: "Hola!",
+              comment_event: "Approved",
+              comment_user_id: user.id
+            }
+          )
 
           subject
         end
@@ -41,6 +49,7 @@ RSpec.describe EnrollmentExemption do
         it "creates a comment" do
           expect(comment.content).to eq("Hola!")
           expect(comment.event).to eq("Approved")
+          expect(comment.user).to eq(user)
         end
 
         it "updates the status" do


### PR DESCRIPTION
Here we store the user_id in the comments table when an action is performed on a registration. 
Then we display the user's email in the comment section

**Approval**
https://eaflood.atlassian.net/browse/RUBY-1499?focusedCommentId=334666