### PR TITLE
Sign out via :get instead of :delete

### DIFF
--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -31,7 +31,6 @@
     <li class="govuk-header__navigation-item">
       <%= link_to t('devise.sign_out'),
               destroy_user_session_path,
-              method: :delete,
               class: "govuk-header__link" %>
     </li>
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -229,7 +229,7 @@ Devise.setup do |config|
   # config.navigational_formats = ['*/*', :html]
 
   # The default HTTP method used to sign out a resource. Default is :delete.
-  config.sign_out_via = :delete
+  config.sign_out_via = :get
 
   # ==> OmniAuth
   # Add a new OmniAuth provider. Check the wiki for more information on setting


### PR DESCRIPTION
- :delete requires jQuery, so the sign out link broke when we removed jQuery