### PR TITLE
Avoid assigning an invited user multiple roles

### DIFF
--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -37,7 +37,7 @@ class InvitationsController < ::Devise::InvitationsController
         res.errors.add :assigned_role, :inclusion
       end
 
-      res.add_role res.assigned_role if res.errors.empty? && res.assigned_role.present?
+      res.add_role res.assigned_role if res.errors.empty? && res.assigned_role.present? && res.roles.empty?
 
       # rubocop:disable Style/SafeNavigation
       # TODO: Tried changing this to use rubocop suggested Safe navigation format

--- a/spec/features/devise/invite_user_feature_spec.rb
+++ b/spec/features/devise/invite_user_feature_spec.rb
@@ -63,6 +63,20 @@ RSpec.feature "Invite user" do
         expect(page).to have_css(".govuk-error-message", text: "Email address has already been taken")
       end
 
+      scenario "Invite a user who has already been invited - doesn't add a new user or role" do
+        user = User.invite!(email: email_addr)
+        user.add_role :data_agent
+
+        fill_in "Email", with: email_addr
+        select "System user", from: "Role"
+
+        expect do
+          click_button "Send an invitation"
+        end.not_to change(User, :count)
+
+        expect(user.roles.map(&:name)).to eq(["data_agent"])
+      end
+
       scenario "Invite user (no role selected)" do
         fill_in "Email", with: email_addr
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1504?focusedCommentId=336619

- When a user is invited, there is no validation to check whether they
already have an open invitation, and they are assigned another role

- Here we avoid assigning the user a new role, if they already have one

- Ideally we would to this with a validation, but the roles are assigned
willy-nilly in the invitations controller