### PR TITLE
Remove old transient_registration records

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem "whenever"
 
 gem "flood_risk_engine",
     git: "https://github.com/DEFRA/flood-risk-engine",
-    branch: "rails6"
+    branch: "fix/timestamps"
 
 gem "defra_ruby_aws"
 gem "defra_ruby_email"

--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem "whenever"
 
 gem "flood_risk_engine",
     git: "https://github.com/DEFRA/flood-risk-engine",
-    branch: "fix/timestamps"
+    branch: "rails6"
 
 gem "defra_ruby_aws"
 gem "defra_ruby_email"

--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,7 @@ group :test do
   gem "rspec_junit_formatter"
   gem "shoulda-matchers", "~> 3.1.1", require: false # Pinned to avoid breaking changes
   gem "simplecov", "~> 0.17.1", require: false
+  gem "whenever-test", "~> 1.0"
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/DEFRA/flood-risk-engine
-  revision: 36f141313f0f4dc5706d37a0ee257a37fd5adfde
-  branch: rails6
+  revision: 183b39d3a81c762ad92529b180e0b3024bdb1c2d
+  branch: fix/timestamps
   specs:
     flood_risk_engine (1.1)
       aasm (~> 4.12)
@@ -97,7 +97,7 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     airbrake (12.0.0)
       airbrake-ruby (~> 6.0)
-    airbrake-ruby (6.0.0)
+    airbrake-ruby (6.0.1)
       rbtree3 (~> 0.5)
     ast (2.4.2)
     async (1.30.1)
@@ -1278,8 +1278,8 @@ GEM
       rest-client (~> 2.0)
     defra_ruby_alert (2.1.1)
       airbrake
-    defra_ruby_area (2.0.1)
-      nokogiri (~> 1.11.1)
+    defra_ruby_area (2.0.2)
+      nokogiri (>= 1.11.1, < 1.13.0)
       rest-client (~> 2.0)
     defra_ruby_aws (0.4.1)
       aws-sdk-s3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/DEFRA/flood-risk-engine
-  revision: 183b39d3a81c762ad92529b180e0b3024bdb1c2d
-  branch: fix/timestamps
+  revision: 982f67ffc0c657dd9dee4a62e1fac6d3b778899a
+  branch: rails6
   specs:
     flood_risk_engine (1.1)
       aasm (~> 4.12)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1588,6 +1588,8 @@ GEM
     websocket-extensions (0.1.5)
     whenever (1.0.0)
       chronic (>= 0.6.3)
+    whenever-test (1.0.1)
+      whenever
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.4.2)
@@ -1638,6 +1640,7 @@ DEPENDENCIES
   uglifier
   validates_timeliness
   whenever
+  whenever-test (~> 1.0)
 
 RUBY VERSION
    ruby 2.7.1p83

--- a/app/services/transient_registration_cleanup_service.rb
+++ b/app/services/transient_registration_cleanup_service.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class TransientRegistrationCleanupService < ::FloodRiskEngine::BaseService
+  def run
+    transient_registrations_to_remove.destroy_all
+  end
+
+  private
+
+  def transient_registrations_to_remove
+    FloodRiskEngine::TransientRegistration.where("created_at < ?", oldest_possible_date)
+  end
+
+  def oldest_possible_date
+    max = Rails.configuration.max_transient_registration_age_days.to_i
+    max.days.ago.beginning_of_day
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -48,5 +48,8 @@ module FloodRiskBackOffice
     # SassC::SyntaxError: Error: "calc(0px)" is not a number for `max'
     # https://github.com/alphagov/govuk-frontend/issues/1350
     config.assets.css_compressor = nil
+
+    # Database cleanup
+    config.max_transient_registration_age_days = ENV["MAX_TRANSIENT_REGISTRATION_AGE_DAYS"] || 30
   end
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -39,3 +39,8 @@ every :day, at: (ENV["EXPORT_SERVICE_EPR_EXPORT_TIME"] || "21:05"), roles: [:db]
   rake "reports:export:epr"
 end
 
+# This is the transient registration cleanup job which will delete all records
+# that are more than 30 days old, as well as associated records
+every :day, at: (ENV["CLEANUP_TRANSIENT_REGISTRATIONS_RUN_TIME"] || "00:35"), roles: [:db] do
+  rake "cleanup:transient_registrations"
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,8 +2,8 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.
@@ -65,8 +65,8 @@ ActiveRecord::Schema.define(version: 2021_08_02_151907) do
 
   create_table "flood_risk_engine_comments", id: :serial, force: :cascade do |t|
     t.integer "user_id"
-    t.integer "commentable_id"
     t.string "commentable_type"
+    t.integer "commentable_id"
     t.text "content"
     t.string "event"
     t.datetime "created_at", null: false
@@ -161,7 +161,6 @@ ActiveRecord::Schema.define(version: 2021_08_02_151907) do
     t.integer "org_type"
     t.string "registration_number", limit: 12
     t.text "searchable_content"
-    t.index ["contact_id"], name: "index_flood_risk_engine_organisations_on_contact_id"
     t.index ["org_type"], name: "index_flood_risk_engine_organisations_on_org_type"
     t.index ["registration_number"], name: "index_flood_risk_engine_organisations_on_registration_number"
     t.index ["searchable_content"], name: "index_flood_risk_engine_organisations_on_searchable_content"
@@ -196,8 +195,8 @@ ActiveRecord::Schema.define(version: 2021_08_02_151907) do
 
   create_table "roles", id: :serial, force: :cascade do |t|
     t.string "name"
-    t.integer "resource_id"
     t.string "resource_type"
+    t.integer "resource_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["name", "resource_type", "resource_id"], name: "index_roles_on_name_and_resource_type_and_resource_id"
@@ -231,6 +230,8 @@ ActiveRecord::Schema.define(version: 2021_08_02_151907) do
     t.bigint "addressable_id"
     t.string "uprn"
     t.string "token"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["addressable_type", "addressable_id"], name: "index_addressables"
   end
 
@@ -238,6 +239,8 @@ ActiveRecord::Schema.define(version: 2021_08_02_151907) do
     t.string "full_name"
     t.string "temp_postcode"
     t.bigint "transient_registration_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["transient_registration_id"], name: "index_transient_people_on_transient_registration_id"
   end
 
@@ -247,6 +250,8 @@ ActiveRecord::Schema.define(version: 2021_08_02_151907) do
     t.date "expires_on"
     t.bigint "transient_registration_id"
     t.bigint "flood_risk_engine_exemption_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["flood_risk_engine_exemption_id"], name: "exemption_id"
     t.index ["transient_registration_id"], name: "transient_registration_id"
   end
@@ -254,6 +259,8 @@ ActiveRecord::Schema.define(version: 2021_08_02_151907) do
   create_table "transient_registrations", force: :cascade do |t|
     t.string "token"
     t.string "workflow_state"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.string "type", default: "FloodRiskEngine::NewRegistration", null: false
     t.string "additional_contact_email"
     t.string "business_type"
@@ -286,8 +293,8 @@ ActiveRecord::Schema.define(version: 2021_08_02_151907) do
     t.datetime "invitation_sent_at"
     t.datetime "invitation_accepted_at"
     t.integer "invitation_limit"
-    t.integer "invited_by_id"
     t.string "invited_by_type"
+    t.integer "invited_by_id"
     t.integer "invitations_count", default: 0
     t.integer "failed_attempts", default: 0, null: false
     t.string "unlock_token"

--- a/lib/tasks/cleanup.rake
+++ b/lib/tasks/cleanup.rake
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+namespace :cleanup do
+  desc "Remove old transient_registrations from the database"
+  task transient_registrations: :environment do
+    TransientRegistrationCleanupService.run
+  end
+end

--- a/spec/lib/tasks/cleanup_spec.rb
+++ b/spec/lib/tasks/cleanup_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Cleanup task", type: :rake do
+  include_context "rake"
+
+  describe "cleanup:transient_registrations" do
+    it "runs without error" do
+      expect { subject.invoke }.not_to raise_error
+    end
+  end
+
+end

--- a/spec/schedule_spec.rb
+++ b/spec/schedule_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "whenever/test"
+require "open3"
+
+# This allows us to ensure that the schedules we have declared in whenever's
+# (https://github.com/javan/whenever) config/schedule.rb are valid.
+# The hope is this saves us from only being able to confirm if something will
+# work by actually running the deployment and seeing if it breaks (or not)
+# See https://github.com/rafaelsales/whenever-test for more details
+
+RSpec.describe "Whenever schedule" do
+  let(:schedule) { Whenever::Test::Schedule.new(file: "config/schedule.rb") }
+
+  it "makes sure 'rake' statements exist" do
+    rake_jobs = schedule.jobs[:rake]
+    expect(rake_jobs.count).to eq(3)
+  end
+
+  it "picks up the area lookup run frequency and time" do
+    job_details = schedule.jobs[:rake].find { |h| h[:task] == "lookups:update:missing_area" }
+
+    expect(job_details[:every][0]).to eq(:day)
+    expect(job_details[:every][1][:at]).to eq("1:05")
+  end
+
+  it "picks up the EPR export run frequency and time" do
+    job_details = schedule.jobs[:rake].find { |h| h[:task] == "reports:export:epr" }
+
+    expect(job_details[:every][0]).to eq(:day)
+    expect(job_details[:every][1][:at]).to eq("21:05")
+  end
+
+  it "picks up the transient registration cleanup execution run frequency and time" do
+    job_details = schedule.jobs[:rake].find { |h| h[:task] == "cleanup:transient_registrations" }
+
+    expect(job_details[:every][0]).to eq(:day)
+    expect(job_details[:every][1][:at]).to eq("00:35")
+  end
+
+  it "can determine the configured cron log output path" do
+    expected_output_file = File.join("/srv/ruby/flood-risk-activity-exemption-back-office/shared/log/", "whenever_cron.log")
+    expect(schedule.sets[:output]).to eq(expected_output_file)
+  end
+
+  it "allows the `whenever` command to be called without raising an error" do
+    Open3.popen3("bundle", "exec", "whenever") do |_, stdout, stderr, wait_thr|
+      expect(stdout.read).to_not be_empty
+      expect(stderr.read).to be_empty
+      expect(wait_thr.value.success?).to eq(true)
+    end
+  end
+end

--- a/spec/schedule_spec.rb
+++ b/spec/schedule_spec.rb
@@ -40,7 +40,8 @@ RSpec.describe "Whenever schedule" do
   end
 
   it "can determine the configured cron log output path" do
-    expected_output_file = File.join("/srv/ruby/flood-risk-activity-exemption-back-office/shared/log/", "whenever_cron.log")
+    expected_output_file = File.join("/srv/ruby/flood-risk-activity-exemption-back-office/shared/log/",
+                                     "whenever_cron.log")
     expect(schedule.sets[:output]).to eq(expected_output_file)
   end
 

--- a/spec/services/transient_registration_cleanup_service_spec.rb
+++ b/spec/services/transient_registration_cleanup_service_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TransientRegistrationCleanupService do
+  describe ".run" do
+    let(:transient_registration) { create(:new_registration, :has_required_data_for_limited_company) }
+    let(:id) { transient_registration.id }
+
+    context "when a transient_registration is older than 30 days" do
+      before do
+        transient_registration.update!(created_at: Time.now - 31.days)
+      end
+
+      it "deletes it" do
+        expect { described_class.run }.to change { FloodRiskEngine::TransientRegistration.where(id: id).count }.from(1).to(0)
+      end
+
+      it "deletes its transient_addresses" do
+        address_id = transient_registration.company_address.id
+
+        expect { described_class.run }.to change { FloodRiskEngine::TransientAddress.where(id: address_id).count }.from(1).to(0)
+      end
+
+      context "when there are transient_people" do
+        let(:transient_registration) { create(:new_registration, :has_required_data_for_partnership) }
+
+        it "deletes its transient_people" do
+          people_count = transient_registration.transient_people.count
+
+          expect { described_class.run }.to change { FloodRiskEngine::TransientPerson.where(transient_registration_id: id).count }.from(people_count).to(0)
+        end
+      end
+
+      it "deletes its transient_registration_exemptions" do
+        re_count = transient_registration.transient_registration_exemptions.count
+
+        expect { described_class.run }.to change { FloodRiskEngine::TransientRegistrationExemption.where(transient_registration_id: id).count }.from(re_count).to(0)
+      end
+    end
+
+    context "when a transient_registration is newer than 30 days" do
+      it "does not delete it" do
+        expect { described_class.run }.to_not change { FloodRiskEngine::TransientRegistration.where(id: id).count }.from(1)
+      end
+    end
+  end
+end

--- a/spec/services/transient_registration_cleanup_service_spec.rb
+++ b/spec/services/transient_registration_cleanup_service_spec.rb
@@ -13,13 +13,17 @@ RSpec.describe TransientRegistrationCleanupService do
       end
 
       it "deletes it" do
-        expect { described_class.run }.to change { FloodRiskEngine::TransientRegistration.where(id: id).count }.from(1).to(0)
+        expect { described_class.run }.to change {
+          FloodRiskEngine::TransientRegistration.where(id: id).count
+        }.from(1).to(0)
       end
 
       it "deletes its transient_addresses" do
         address_id = transient_registration.company_address.id
 
-        expect { described_class.run }.to change { FloodRiskEngine::TransientAddress.where(id: address_id).count }.from(1).to(0)
+        expect { described_class.run }.to change {
+          FloodRiskEngine::TransientAddress.where(id: address_id).count
+        }.from(1).to(0)
       end
 
       context "when there are transient_people" do
@@ -28,20 +32,26 @@ RSpec.describe TransientRegistrationCleanupService do
         it "deletes its transient_people" do
           people_count = transient_registration.transient_people.count
 
-          expect { described_class.run }.to change { FloodRiskEngine::TransientPerson.where(transient_registration_id: id).count }.from(people_count).to(0)
+          expect { described_class.run }.to change {
+            FloodRiskEngine::TransientPerson.where(transient_registration_id: id).count
+          }.from(people_count).to(0)
         end
       end
 
       it "deletes its transient_registration_exemptions" do
         re_count = transient_registration.transient_registration_exemptions.count
 
-        expect { described_class.run }.to change { FloodRiskEngine::TransientRegistrationExemption.where(transient_registration_id: id).count }.from(re_count).to(0)
+        expect { described_class.run }.to change {
+          FloodRiskEngine::TransientRegistrationExemption.where(transient_registration_id: id).count
+        }.from(re_count).to(0)
       end
     end
 
     context "when a transient_registration is newer than 30 days" do
       it "does not delete it" do
-        expect { described_class.run }.to_not change { FloodRiskEngine::TransientRegistration.where(id: id).count }.from(1)
+        expect { described_class.run }.to_not change {
+          FloodRiskEngine::TransientRegistration.where(id: id).count
+        }.from(1)
       end
     end
   end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1685

We want to clean up old transient_registration records that have been sitting around for more than 30 days.

---

Depends on https://github.com/DEFRA/flood-risk-engine/pull/448