### PR TITLE
Prefer active_record_store over cookie_store

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: "_flood_risk_back_office_session"
+Rails.application.config.session_store :active_record_store, key: "_flood_risk_back_office_session"

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -44,3 +44,10 @@ end
 every :day, at: (ENV["CLEANUP_TRANSIENT_REGISTRATIONS_RUN_TIME"] || "00:35"), roles: [:db] do
   rake "cleanup:transient_registrations"
 end
+
+# This runs daily and cleans up sessions that have not been updated in the
+# last 30 days. The intention is to prevent the session table from growing
+# too big. More info: https://github.com/rails/activerecord-session_store
+every :day, at: (ENV["CLEANUP_SESSIONS_TABLE_TIME"] || "01:00"), roles: [:db] do
+  rake "db:sessions:trim"
+end

--- a/spec/schedule_spec.rb
+++ b/spec/schedule_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Whenever schedule" do
 
   it "makes sure 'rake' statements exist" do
     rake_jobs = schedule.jobs[:rake]
-    expect(rake_jobs.count).to eq(3)
+    expect(rake_jobs.count).to eq(4)
   end
 
   it "picks up the area lookup run frequency and time" do


### PR DESCRIPTION
- This is an attempt to fix session replay bug that came up in the PEN test (3.1.1)

- The engine enforces use of the activerecord-session_store gem,
which should use a database table to store the session data.

- But, the app was using the cookie_store instead. The database table is there,
but unused.

- To prevent the databased table growing too large, we are adding a scheduled t
`db:sessions:trim` to clean up sessions that have been unused for 30 days.

More info: https://github.com/rails/activerecord-session_store

Relates to: https://eaflood.atlassian.net/browse/RUBY-1715