### PR TITLE
[1910] adds missing libraries

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,9 @@ gem "devise_invitable"
 gem "devise-security"
 gem "jquery-rails", "~> 4.4"
 gem "kaminari"
-gem "net-smtp"
+gem "net-imap", require: false
+gem "net-pop", require: false
+gem "net-smtp", require: false
 gem "paper_trail"
 gem "pg"
 gem "pundit"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -313,6 +313,14 @@ GEM
     minitest (5.16.0)
     multi_json (1.15.0)
     multipart-post (2.1.1)
+    net-imap (0.2.3)
+      digest
+      net-protocol
+      strscan
+    net-pop (0.1.1)
+      digest
+      net-protocol
+      timeout
     net-protocol (0.1.3)
       timeout
     net-smtp (0.3.1)
@@ -468,6 +476,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    strscan (3.0.3)
     sucker_punch (2.1.2)
       concurrent-ruby (~> 1.0)
     thor (1.2.1)
@@ -531,6 +540,8 @@ DEPENDENCIES
   jquery-rails (~> 4.4)
   kaminari
   launchy
+  net-imap
+  net-pop
   net-smtp
   paper_trail
   passenger


### PR DESCRIPTION
Deploys to dev are failing, this aims to remedy this by including gems/libraries no longer included in ruby 3.1

https://stackoverflow.com/questions/70500220/rails-7-ruby-3-1-loaderror-cannot-load-such-file-net-smtp/70500221#70500221