### PR TITLE
Fix/ruby 2805 missing translation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,10 @@ gem "flood_risk_engine",
     git: "https://github.com/DEFRA/flood-risk-engine",
     branch: "main"
 
+# This is specified in the engine gemspec,
+# but need to specify here also to pick up i18n locales
+gem "defra_ruby_validators"
+
 gem "defra_ruby_aws"
 gem "defra_ruby_template"
 gem "github_changelog_generator", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DEFRA/flood-risk-engine
-  revision: b3429f5d8e695462eb1af03f50955ad45c5177d2
+  revision: e216a9b94a3a3bf49ecb6622390be12434b07ceb
   branch: main
   specs:
     flood_risk_engine (1.2)
@@ -182,7 +182,7 @@ GEM
     console (1.23.3)
       fiber-annotation
       fiber-local
-    crack (0.4.6)
+    crack (1.0.0)
       bigdecimal
       rexml
     crass (1.0.6)
@@ -297,7 +297,7 @@ GEM
       concurrent-ruby (~> 1.0)
     io-console (0.7.2)
     io-event (1.4.2)
-    irb (1.11.1)
+    irb (1.11.2)
       rdoc
       reline (>= 0.4.2)
     jmespath (1.6.2)
@@ -306,7 +306,8 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (2.7.1)
-    jwt (2.7.1)
+    jwt (2.8.0)
+      base64
     kaminari (1.2.2)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.2.2)
@@ -334,15 +335,14 @@ GEM
     matrix (0.4.2)
     mime-types (3.5.2)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2023.1205)
+    mime-types-data (3.2024.0206)
     mini_mime (1.1.5)
-    mini_portile2 (2.8.5)
-    minitest (5.21.2)
+    minitest (5.22.2)
     multi_json (1.15.0)
     mutex_m (0.2.0)
     net-http (0.4.1)
       uri
-    net-imap (0.4.9.1)
+    net-imap (0.4.10)
       date
       net-protocol
     net-pop (0.1.2)
@@ -353,8 +353,9 @@ GEM
       net-protocol
     netrc (0.11.0)
     nio4r (2.7.0)
-    nokogiri (1.16.0)
-      mini_portile2 (~> 2.8.2)
+    nokogiri (1.16.2-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.16.2-x86_64-linux)
       racc (~> 1.4)
     notifications-ruby-client (6.0.0)
       jwt (>= 1.5, < 3)
@@ -373,7 +374,7 @@ GEM
     passenger (6.0.19)
       rack
       rake (>= 0.8.1)
-    pg (1.5.4)
+    pg (1.5.5)
     phonelib (0.8.7)
     poltergeist (1.18.1)
       capybara (>= 2.1, < 4)
@@ -556,7 +557,7 @@ GEM
     vcr (6.2.0)
     warden (1.2.9)
       rack (>= 2.0.9)
-    webmock (3.19.1)
+    webmock (3.20.0)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
@@ -570,10 +571,11 @@ GEM
       whenever
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.6.12)
+    zeitwerk (2.6.13)
 
 PLATFORMS
-  ruby
+  x86_64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   awesome_print
@@ -585,6 +587,7 @@ DEPENDENCIES
   defra_ruby_aws
   defra_ruby_style
   defra_ruby_template
+  defra_ruby_validators
   devise
   devise-security
   devise_invitable

--- a/app/controllers/enrollments/organisations_controller.rb
+++ b/app/controllers/enrollments/organisations_controller.rb
@@ -20,8 +20,7 @@ module Enrollments
 
     def load_defaults
       @organisation = Organisation.find(params[:id])
-      @enrollment = FloodRiskEngine::Enrollment.find_by(token: params[:enrollment_id]) ||
-                    FloodRiskEngine::Enrollment.find(params[:enrollment_id])
+      @enrollment = FloodRiskEngine::Enrollment.find_by(token: params[:enrollment_id])
       @enrollment_exemption = @enrollment.enrollment_exemptions.first
     end
 

--- a/app/controllers/enrollments/organisations_controller.rb
+++ b/app/controllers/enrollments/organisations_controller.rb
@@ -20,7 +20,8 @@ module Enrollments
 
     def load_defaults
       @organisation = Organisation.find(params[:id])
-      @enrollment = FloodRiskEngine::Enrollment.find_by(token: params[:enrollment_id])
+      @enrollment = FloodRiskEngine::Enrollment.find_by(token: params[:enrollment_id]) ||
+                    FloodRiskEngine::Enrollment.find(params[:enrollment_id])
       @enrollment_exemption = @enrollment.enrollment_exemptions.first
     end
 

--- a/app/decorators/models/flood_risk_engine/enrollment_exemption_decorator.rb
+++ b/app/decorators/models/flood_risk_engine/enrollment_exemption_decorator.rb
@@ -1,5 +1,5 @@
 FloodRiskEngine::EnrollmentExemption.class_eval do
-  belongs_to :accept_reject_decision_user, class_name: "User"
+  belongs_to :accept_reject_decision_user, class_name: "User", optional: true
 
   # rubocop:disable Style/Lambda
 

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -4,14 +4,9 @@ class Address < ActiveRecord::Base
   validates :premises, presence: true
   validates :street_address, presence: true
   validates :city, presence: true
-  validates :postcode, presence: true
-  validates :postcode, length: { maximum: 8 }
+  validates :postcode, "defra_ruby/validators/postcode": true
 
   def to_param
     token
-  end
-
-  def address_finder_errored!
-    # Invoked by postcode validator, but we don't want/need it here
   end
 end

--- a/app/models/enrollment_exemption.rb
+++ b/app/models/enrollment_exemption.rb
@@ -8,8 +8,6 @@ class EnrollmentExemption < FloodRiskEngine::EnrollmentExemption
   validates :comment_content, presence: true, length: { maximum: 500 }, if: :commentable?
   before_save :create_comment, if: :commentable?
 
-  delegate :reference_number, to: :enrollment
-
   def action!(params)
     @commentable = true
     update(params)
@@ -19,6 +17,10 @@ class EnrollmentExemption < FloodRiskEngine::EnrollmentExemption
     def status_keys
       FloodRiskEngine::EnrollmentExemption.statuses.except(:building).keys
     end
+  end
+
+  def reference_number
+    enrollment.ref_number
   end
 
   private

--- a/app/presenters/enrollment_exemption_presenter.rb
+++ b/app/presenters/enrollment_exemption_presenter.rb
@@ -203,8 +203,7 @@ class EnrollmentExemptionPresenter < Presenter
   end
 
   def edit_organisation_link(organisation)
-    Rails.logger.warn "\n++++++++ edit_organisation_link for: #{enrollment}, #{organisation}\n"
-    link_to(I18n.t(".edit"), edit_enrollment_organisation_path(enrollment.id, organisation))
+    link_to(I18n.t(".edit"), edit_enrollment_organisation_path(enrollment, organisation))
   end
 
   def organisation_type

--- a/app/presenters/enrollment_exemption_presenter.rb
+++ b/app/presenters/enrollment_exemption_presenter.rb
@@ -26,7 +26,6 @@ class EnrollmentExemptionPresenter < Presenter
            :exemption_location,
            :correspondence_contact,
            :secondary_contact,
-           :reference_number,
            to: :enrollment, allow_nil: true
 
   delegate :code, :summary, to: :exemption, allow_nil: true
@@ -78,6 +77,10 @@ class EnrollmentExemptionPresenter < Presenter
     return "" unless enrollment_exemption.deregister_reason
 
     enrollment_exemption.deregister_reason.humanize
+  end
+
+  def reference_number
+    enrollment.ref_number
   end
 
   def status
@@ -200,7 +203,8 @@ class EnrollmentExemptionPresenter < Presenter
   end
 
   def edit_organisation_link(organisation)
-    link_to(I18n.t(".edit"), edit_enrollment_organisation_path(enrollment, organisation))
+    Rails.logger.warn "\n++++++++ edit_organisation_link for: #{enrollment}, #{organisation}\n"
+    link_to(I18n.t(".edit"), edit_enrollment_organisation_path(enrollment.id, organisation))
   end
 
   def organisation_type

--- a/app/presenters/presenter.rb
+++ b/app/presenters/presenter.rb
@@ -67,11 +67,11 @@ class Presenter < SimpleDelegator
   end
 
   def blank_value
-    content_tag :em, t("presenters.blank"), class: "text-muted"
+    content_tag :em, I18n.t("presenters.blank"), class: "text-muted"
   end
 
   def nil_value
-    content_tag :em, t("presenters.nil"), class: "text-muted"
+    content_tag :em, I18n.t("presenters.nil"), class: "text-muted"
   end
 
   def friendly_date(date)
@@ -80,7 +80,7 @@ class Presenter < SimpleDelegator
   end
 
   def friendly_expiry_date(date)
-    return t("presenters.no_expiry_date_present") unless date
+    return I18n.t("presenters.no_expiry_date_present") unless date
 
     I18n.l(date.to_date, format: :long)
   end

--- a/app/presenters/presenter.rb
+++ b/app/presenters/presenter.rb
@@ -62,27 +62,8 @@ class Presenter < SimpleDelegator
     super
   end
 
-  def default_url_options
-    Rails.application.routes.default_url_options
-  end
-
   def blank_value
     content_tag :em, I18n.t("presenters.blank"), class: "text-muted"
-  end
-
-  def nil_value
-    content_tag :em, I18n.t("presenters.nil"), class: "text-muted"
-  end
-
-  def friendly_date(date)
-    formatted_date = date && I18n.l(date.to_date, format: :long)
-    formatted_date || ""
-  end
-
-  def friendly_expiry_date(date)
-    return I18n.t("presenters.no_expiry_date_present") unless date
-
-    I18n.l(date.to_date, format: :long)
   end
 
   # Add any common methods like app-specific date formatters etc here

--- a/app/services/notify/registration_approved_email_service.rb
+++ b/app/services/notify/registration_approved_email_service.rb
@@ -9,7 +9,7 @@ module Notify
         email_address: @recipient_address,
         template_id:,
         personalisation: {
-          registration_number: @enrollment.reference_number,
+          registration_number: @enrollment.ref_number,
           exemption_description: enrollment_description,
           grid_reference:,
           assets: assets?,

--- a/app/services/notify/registration_rejected_email_service.rb
+++ b/app/services/notify/registration_rejected_email_service.rb
@@ -9,7 +9,7 @@ module Notify
         email_address: @recipient_address,
         template_id:,
         personalisation: {
-          registration_number: @enrollment.reference_number
+          registration_number: @enrollment.ref_number
         }
       }
     end

--- a/app/views/enrollments/organisations/edit.html.erb
+++ b/app/views/enrollments/organisations/edit.html.erb
@@ -15,8 +15,7 @@
     <% end %>
 
     <p class="govuk-body">
-      <%= link_to t("cancel_go_back"), admin_enrollment_exemption_path(@enrollment_exemption)  %>
+      <%= link_to t("cancel_go_back"), admin_enrollment_exemption_path(@enrollment_exemption) %>
     </p>
   </div>
 </div>
-

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -21,7 +21,7 @@ Rails.application.configure do
   config.action_controller.perform_caching = false
 
   # Raise exceptions instead of rendering exception templates.
-  config.action_dispatch.show_exceptions = false
+  config.action_dispatch.show_exceptions = :none
 
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,6 +7,8 @@ def create_user(email, role)
     email:,
     password: ENV.fetch("DEFAULT_PASSWORD", "Secret123")
   )
+  Rolify.resource_types << "User" unless Rolify.resource_types.include?("User")
+  Role.create(name: role)
   user.add_role role
 end
 

--- a/lib/tasks/bulk_load.thor
+++ b/lib/tasks/bulk_load.thor
@@ -111,7 +111,7 @@ module Flood
 
         puts("\nLast Enrollment generated:")
         puts "ID: #{FloodRiskEngine::Enrollment.last.id}"
-        puts "RefNumber [#{FloodRiskEngine::Enrollment.last.reference_number}]"
+        puts "RefNumber [#{FloodRiskEngine::Enrollment.last.ref_number}]"
 
         conn = ActiveRecord::Base.connection
         vacuum_after_insert(conn)

--- a/spec/features/admin/view_enrollment_exemption_spec.rb
+++ b/spec/features/admin/view_enrollment_exemption_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe "View Enrollment Exemption Detail" do
         visit admin_enrollment_exemption_path(enrollment_exemption)
 
         within "#registration-details" do
-          expect(page).to have_css("td", text: enrollment.reference_number)
+          expect(page).to have_css("td", text: enrollment.ref_number)
         end
 
         within "#correspondence-contact-details" do

--- a/spec/features/edit_address_spec.rb
+++ b/spec/features/edit_address_spec.rb
@@ -29,6 +29,6 @@ RSpec.describe "Edit address" do
     fill_in "Postcode", with: "foo-bar-foo"
     click_on "Continue"
 
-    expect(page).to have_css(".govuk-error-message", text: "Postcode is too long")
+    expect(page).to have_css(".govuk-error-message", text: "Error: Enter a valid postcode - there’s a mistake in that one")
   end
 end

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -6,6 +6,5 @@ RSpec.describe Address do
     it { is_expected.to validate_presence_of(:street_address) }
     it { is_expected.to validate_presence_of(:city) }
     it { is_expected.to validate_presence_of(:postcode) }
-    it { is_expected.to validate_length_of(:postcode).is_at_most(8) }
   end
 end

--- a/spec/presenters/enrollment_exemption_presenter_spec.rb
+++ b/spec/presenters/enrollment_exemption_presenter_spec.rb
@@ -27,4 +27,8 @@ RSpec.describe EnrollmentExemptionPresenter, type: :presenter do
       presenter.status_tag
     end
   end
+
+  describe "#blank_value" do
+    it { expect(presenter.blank_value).to match /Not specified/ }
+  end
 end

--- a/spec/presenters/enrollment_exemption_presenter_spec.rb
+++ b/spec/presenters/enrollment_exemption_presenter_spec.rb
@@ -29,6 +29,6 @@ RSpec.describe EnrollmentExemptionPresenter, type: :presenter do
   end
 
   describe "#blank_value" do
-    it { expect(presenter.blank_value).to match /Not specified/ }
+    it { expect(presenter.blank_value).to match(/Not specified/) }
   end
 end

--- a/spec/queries/enrollment_exemption_search_query_spec.rb
+++ b/spec/queries/enrollment_exemption_search_query_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe EnrollmentExemptionSearchQuery, type: :query do
   end
 
   describe "by reference_number" do
-    let(:search_term) { approved_individual.reference_number.downcase }
+    let(:search_term) { approved_individual.ref_number.downcase }
 
     it "finds the approved enrollment" do
       expect(subject).to eq([approved_individual])

--- a/spec/services/notify/registration_approved_email_service_spec.rb
+++ b/spec/services/notify/registration_approved_email_service_spec.rb
@@ -42,7 +42,7 @@ module Notify
           email_address: recipient_address,
           template_id: "c814587b-1368-4f64-a9b9-da101f9a078b",
           personalisation: {
-            registration_number: enrollment.reference_number,
+            registration_number: enrollment.ref_number,
             exemption_description: expected_exemption_description,
             grid_reference: enrollment.exemption_location.grid_reference,
             assets: "yes",

--- a/spec/services/notify/registration_rejected_email_service_spec.rb
+++ b/spec/services/notify/registration_rejected_email_service_spec.rb
@@ -15,7 +15,7 @@ module Notify
           email_address: recipient_address,
           template_id:,
           personalisation: {
-            registration_number: enrollment.reference_number
+            registration_number: enrollment.ref_number
           }
         }
       end


### PR DESCRIPTION
Switch to defra_ruby_validators for postcode validation
Change enrollment reference_number calls to ref_number as per the engine change
https://eaflood.atlassian.net/browse/RUBY-2805